### PR TITLE
Add health check REST endpoint

### DIFF
--- a/includes/class-health-controller.php
+++ b/includes/class-health-controller.php
@@ -10,6 +10,7 @@ namespace AI_Feedback;
 use WP_REST_Controller;
 use WP_REST_Server;
 use WP_REST_Response;
+use WP_Error;
 
 /**
  * Health check REST API controller.
@@ -56,10 +57,18 @@ class Health_Controller extends WP_REST_Controller {
 	 * Requires edit_posts capability so only authenticated editors
 	 * and above can access dependency/version details.
 	 *
-	 * @return bool
+	 * @return true|WP_Error
 	 */
-	public function get_health_permissions_check(): bool {
-		return \current_user_can( 'edit_posts' );
+	public function get_health_permissions_check() {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access health status.', 'ai-feedback' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
 	}
 
 	/**
@@ -69,17 +78,18 @@ class Health_Controller extends WP_REST_Controller {
 	 */
 	public function get_health(): WP_REST_Response {
 		$ai_available = class_exists( 'WordPress\AiClient\AiClient' );
+		$notes_api    = version_compare( get_bloginfo( 'version' ), '6.9', '>=' );
 
-		$status = $ai_available ? 'ok' : 'degraded';
+		$status = ( $ai_available && $notes_api ) ? 'ok' : 'degraded';
 
 		return new WP_REST_Response(
 			array(
 				'status'       => $status,
 				'version'      => AI_FEEDBACK_VERSION,
 				'ai_available' => $ai_available,
-				'notes_api'    => true,
+				'notes_api'    => $notes_api,
 				'php_version'  => PHP_VERSION,
-				'wp_version'   => \get_bloginfo( 'version' ),
+				'wp_version'   => get_bloginfo( 'version' ),
 			)
 		);
 	}

--- a/includes/class-health-controller.php
+++ b/includes/class-health-controller.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Health Check REST API Controller
+ *
+ * @package AI_Feedback
+ */
+
+namespace AI_Feedback;
+
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Response;
+
+/**
+ * Health check REST API controller.
+ *
+ * Provides a /ai-feedback/v1/health endpoint for checking
+ * plugin status and dependency availability.
+ */
+class Health_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'ai-feedback/v1';
+
+	/**
+	 * Rest base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'health';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_health' ),
+					'permission_callback' => array( $this, 'get_health_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check for health endpoint.
+	 *
+	 * Requires edit_posts capability so only authenticated editors
+	 * and above can access dependency/version details.
+	 *
+	 * @return bool
+	 */
+	public function get_health_permissions_check(): bool {
+		return \current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Get health status.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_health(): WP_REST_Response {
+		$ai_available = class_exists( 'WordPress\AiClient\AiClient' );
+
+		$status = $ai_available ? 'ok' : 'degraded';
+
+		return new WP_REST_Response(
+			array(
+				'status'       => $status,
+				'version'      => AI_FEEDBACK_VERSION,
+				'ai_available' => $ai_available,
+				'notes_api'    => true,
+				'php_version'  => PHP_VERSION,
+				'wp_version'   => \get_bloginfo( 'version' ),
+			)
+		);
+	}
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -48,6 +48,13 @@ class Plugin {
 	private ?Notes_Controller $notes_controller = null;
 
 	/**
+	 * Health controller instance.
+	 *
+	 * @var Health_Controller|null
+	 */
+	private ?Health_Controller $health_controller = null;
+
+	/**
 	 * Get plugin instance.
 	 *
 	 * @return Plugin
@@ -98,6 +105,9 @@ class Plugin {
 
 		$this->notes_controller = new Notes_Controller();
 		$this->notes_controller->register_routes();
+
+		$this->health_controller = new Health_Controller();
+		$this->health_controller->register_routes();
 	}
 
 	/**

--- a/tests/php/HealthControllerTest.php
+++ b/tests/php/HealthControllerTest.php
@@ -177,5 +177,6 @@ class HealthControllerTest extends TestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data( 'rest_forbidden' )['status'] );
 	}
 }

--- a/tests/php/HealthControllerTest.php
+++ b/tests/php/HealthControllerTest.php
@@ -15,7 +15,6 @@ if ( ! defined( 'AI_FEEDBACK_VERSION' ) ) {
 	define( 'AI_FEEDBACK_VERSION', '0.1.0' );
 }
 
-
 /**
  * Test cases for Health_Controller.
  */
@@ -34,6 +33,16 @@ class HealthControllerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->controller = new Health_Controller();
+		// Default to authenticated user with permissions.
+		$GLOBALS['test_current_user_can'] = true;
+	}
+
+	/**
+	 * Clean up globals after each test.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['test_current_user_can'] );
+		parent::tearDown();
 	}
 
 	/**
@@ -52,13 +61,13 @@ class HealthControllerTest extends TestCase {
 	}
 
 	/**
-	 * Test health response returns correct version.
+	 * Test health response returns correct version using constant.
 	 */
 	public function test_health_response_version(): void {
 		$response = $this->controller->get_health();
 		$data     = $response->get_data();
 
-		$this->assertSame( '0.1.0', $data['version'] );
+		$this->assertSame( AI_FEEDBACK_VERSION, $data['version'] );
 	}
 
 	/**
@@ -82,9 +91,20 @@ class HealthControllerTest extends TestCase {
 	}
 
 	/**
-	 * Test notes_api is always true.
+	 * Test notes_api is computed dynamically from WP version.
 	 */
-	public function test_health_response_notes_api(): void {
+	public function test_health_response_notes_api_is_boolean(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertIsBool( $data['notes_api'] );
+	}
+
+	/**
+	 * Test notes_api is true when WP version >= 6.9.
+	 */
+	public function test_health_notes_api_true_for_supported_wp(): void {
+		// Our mock returns '7.0' which is >= 6.9.
 		$response = $this->controller->get_health();
 		$data     = $response->get_data();
 
@@ -102,17 +122,29 @@ class HealthControllerTest extends TestCase {
 	}
 
 	/**
-	 * Test status reflects AI availability.
+	 * Test status is ok when both AI client and Notes API are available.
 	 */
-	public function test_health_status_reflects_ai_availability(): void {
+	public function test_health_status_ok_when_dependencies_available(): void {
 		$response = $this->controller->get_health();
 		$data     = $response->get_data();
 
-		if ( $data['ai_available'] ) {
+		// In the test environment AiClient is loaded via Composer and
+		// the mocked WP version is 7.0 (>= 6.9), so both are available.
+		if ( $data['ai_available'] && $data['notes_api'] ) {
 			$this->assertSame( 'ok', $data['status'] );
 		} else {
 			$this->assertSame( 'degraded', $data['status'] );
 		}
+	}
+
+	/**
+	 * Test status value is always ok or degraded.
+	 */
+	public function test_health_status_is_valid_value(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertContains( $data['status'], array( 'ok', 'degraded' ) );
 	}
 
 	/**
@@ -122,5 +154,28 @@ class HealthControllerTest extends TestCase {
 		$response = $this->controller->get_health();
 
 		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test permission check returns true for authorized users.
+	 */
+	public function test_permissions_check_allows_authorized_user(): void {
+		$GLOBALS['test_current_user_can'] = true;
+
+		$result = $this->controller->get_health_permissions_check();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test permission check returns WP_Error for unauthorized users.
+	 */
+	public function test_permissions_check_denies_unauthorized_user(): void {
+		$GLOBALS['test_current_user_can'] = false;
+
+		$result = $this->controller->get_health_permissions_check();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
 	}
 }

--- a/tests/php/HealthControllerTest.php
+++ b/tests/php/HealthControllerTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Tests for Health_Controller.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Health_Controller;
+
+// Mock WordPress constants needed by the controller.
+if ( ! defined( 'AI_FEEDBACK_VERSION' ) ) {
+	define( 'AI_FEEDBACK_VERSION', '0.1.0' );
+}
+
+
+/**
+ * Test cases for Health_Controller.
+ */
+class HealthControllerTest extends TestCase {
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var Health_Controller
+	 */
+	private Health_Controller $controller;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->controller = new Health_Controller();
+	}
+
+	/**
+	 * Test health endpoint returns expected fields.
+	 */
+	public function test_health_response_has_required_fields(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertArrayHasKey( 'version', $data );
+		$this->assertArrayHasKey( 'ai_available', $data );
+		$this->assertArrayHasKey( 'notes_api', $data );
+		$this->assertArrayHasKey( 'php_version', $data );
+		$this->assertArrayHasKey( 'wp_version', $data );
+	}
+
+	/**
+	 * Test health response returns correct version.
+	 */
+	public function test_health_response_version(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertSame( '0.1.0', $data['version'] );
+	}
+
+	/**
+	 * Test health response returns PHP version.
+	 */
+	public function test_health_response_php_version(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertSame( PHP_VERSION, $data['php_version'] );
+	}
+
+	/**
+	 * Test health response returns WP version.
+	 */
+	public function test_health_response_wp_version(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertSame( '7.0', $data['wp_version'] );
+	}
+
+	/**
+	 * Test notes_api is always true.
+	 */
+	public function test_health_response_notes_api(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['notes_api'] );
+	}
+
+	/**
+	 * Test ai_available is a boolean.
+	 */
+	public function test_health_response_ai_available_is_boolean(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		$this->assertIsBool( $data['ai_available'] );
+	}
+
+	/**
+	 * Test status reflects AI availability.
+	 */
+	public function test_health_status_reflects_ai_availability(): void {
+		$response = $this->controller->get_health();
+		$data     = $response->get_data();
+
+		if ( $data['ai_available'] ) {
+			$this->assertSame( 'ok', $data['status'] );
+		} else {
+			$this->assertSame( 'degraded', $data['status'] );
+		}
+	}
+
+	/**
+	 * Test response has 200 status code.
+	 */
+	public function test_health_response_status_code(): void {
+		$response = $this->controller->get_health();
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -36,6 +36,58 @@ if (! function_exists('esc_html__') ) {
     }
 }
 
+// Mock WP REST classes if not available.
+if ( ! class_exists( 'WP_REST_Controller' ) ) {
+	class WP_REST_Controller {
+		protected $namespace;
+		protected $rest_base;
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Server' ) ) {
+	class WP_REST_Server {
+		const READABLE = 'GET';
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		public $data;
+		public $status;
+
+		public function __construct( $data = null, $status = 200 ) {
+			$this->data   = $data;
+			$this->status = $status;
+		}
+
+		public function get_data() {
+			return $this->data;
+		}
+
+		public function get_status() {
+			return $this->status;
+		}
+	}
+}
+
+if ( ! function_exists( 'get_bloginfo' ) ) {
+	/**
+	 * Mock get_bloginfo for tests.
+	 *
+	 * @param  string $show The info to retrieve.
+	 * @return string The requested info.
+	 */
+	function get_bloginfo( $show ) {
+		if ( 'version' === $show ) {
+			return '7.0';
+		}
+		return '';
+	}
+}
+
+// Load classes that depend on WP REST mocks.
+require_once $includes_dir . 'class-health-controller.php';
+
 // Mock WP_Error class if not available.
 if (! class_exists('WP_Error') ) {
     class WP_Error

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -99,10 +99,8 @@ if ( ! function_exists( 'current_user_can' ) ) {
 	}
 }
 
-// Load classes that depend on WP REST mocks.
-require_once $includes_dir . 'class-health-controller.php';
-
 // Mock WP_Error class if not available.
+// Must be defined before loading plugin classes that use WP_Error in method signatures.
 if (! class_exists('WP_Error') ) {
     class WP_Error
     {
@@ -237,6 +235,9 @@ if (! function_exists('is_wp_error') ) {
         return ( $thing instanceof WP_Error );
     }
 }
+
+// Load classes that depend on WP REST and WP_Error mocks.
+require_once $includes_dir . 'class-health-controller.php';
 
 // Mock WordPress sanitization functions.
 if (! function_exists('wp_kses_post') ) {

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -85,6 +85,20 @@ if ( ! function_exists( 'get_bloginfo' ) ) {
 	}
 }
 
+if ( ! function_exists( 'current_user_can' ) ) {
+	/**
+	 * Mock current_user_can for tests.
+	 *
+	 * Defaults to true. Override via $GLOBALS['test_current_user_can'].
+	 *
+	 * @param  string $capability The capability to check.
+	 * @return bool Whether the user has the capability.
+	 */
+	function current_user_can( $capability ) {
+		return $GLOBALS['test_current_user_can'] ?? true;
+	}
+}
+
 // Load classes that depend on WP REST mocks.
 require_once $includes_dir . 'class-health-controller.php';
 


### PR DESCRIPTION
## Summary
- Adds `GET /ai-feedback/v1/health` endpoint for checking plugin status and dependencies
- Returns status (`ok` or `degraded`), plugin version, AI client availability, PHP/WP versions
- Requires `edit_posts` capability
- 8 unit tests

## Response format
```json
{
  "status": "ok",
  "version": "0.1.0",
  "ai_available": true,
  "notes_api": true,
  "php_version": "8.2.0",
  "wp_version": "7.0"
}
```

## Test plan
- [ ] Verify endpoint returns 200 with expected fields when authenticated
- [ ] Verify endpoint returns 403 for unauthenticated requests
- [ ] Verify status is "degraded" when AI client plugin is deactivated
- [ ] `./vendor/bin/phpunit tests/php/HealthControllerTest.php` — 8 tests pass

Fixes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health-check API endpoint that reports overall status (ok/degraded), AI availability, plugin version, PHP version, and WordPress version; access is permission-checked.

* **Tests**
  * Added tests validating the health endpoint payload, status logic, HTTP response code, and permission behavior; included test bootstrap support to simulate required runtime pieces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->