### PR TITLE
Add few-shot feedback examples to AI prompts

### DIFF
--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -93,9 +93,11 @@ class Prompt_Builder {
 		$prompt .= "    }\n";
 		$prompt .= "  ]\n";
 		$prompt .= "}\n\n";
-		$few_shot_examples = $this->get_few_shot_examples( $options['locale'] );
+		$few_shot_examples = $this->get_few_shot_examples( $options['locale'] ?? 'en_US' );
 
-		// Only append examples if the prompt stays within a safe token budget.
+		// Only append examples if the base prompt is already under the character
+		// budget. 12000 chars ≈ 3000 tokens — conservative to avoid inflating cost
+		// on very long documents while staying well within model context limits.
 		if ( strlen( $prompt ) + strlen( $few_shot_examples ) < 12000 ) {
 			$prompt .= $few_shot_examples . "\n\n";
 		}
@@ -430,8 +432,9 @@ class Prompt_Builder {
 	private function get_few_shot_examples( string $locale = 'en_US' ): string {
 		$language_note = '';
 		if ( 'en_US' !== $locale && 'en' !== substr( $locale, 0, 2 ) ) {
-			$language_note = "Note: These examples are in English for format reference only. "
-				. "Your actual feedback MUST be written in the language specified in the LANGUAGE section above.\n\n";
+			$language_note = 'Note: These examples are in English for format reference only. '
+				. 'Your actual feedback MUST be written in the language specified in the LANGUAGE section above.'
+				. "\n\n";
 		}
 
 		$examples = <<<'EOT'

--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -93,7 +93,13 @@ class Prompt_Builder {
 		$prompt .= "    }\n";
 		$prompt .= "  ]\n";
 		$prompt .= "}\n\n";
-		$prompt .= $this->get_few_shot_examples() . "\n\n";
+		$few_shot_examples = $this->get_few_shot_examples( $options['locale'] );
+
+		// Only append examples if the prompt stays within a safe token budget.
+		if ( strlen( $prompt ) + strlen( $few_shot_examples ) < 12000 ) {
+			$prompt .= $few_shot_examples . "\n\n";
+		}
+
 		$prompt .= "IMPORTANT:\n";
 		$prompt .= '- The "block_id" must exactly match one of the block IDs provided in the document' . "\n";
 		$prompt .= "- Return ONLY valid JSON, no additional text or explanation\n";
@@ -418,58 +424,98 @@ class Prompt_Builder {
 	 * Provides reference examples for each feedback category and severity
 	 * level so the AI produces consistently formatted, high-quality feedback.
 	 *
+	 * @param  string $locale WordPress locale code.
 	 * @return string Few-shot examples for the prompt.
 	 */
-	private function get_few_shot_examples(): string {
-		$examples  = "REFERENCE EXAMPLES:\n";
-		$examples .= "Use these as a guide for the quality, format, and tone of your feedback:\n\n";
+	private function get_few_shot_examples( string $locale = 'en_US' ): string {
+		$language_note = '';
+		if ( 'en_US' !== $locale && 'en' !== substr( $locale, 0, 2 ) ) {
+			$language_note = "Note: These examples are in English for format reference only. "
+				. "Your actual feedback MUST be written in the language specified in the LANGUAGE section above.\n\n";
+		}
 
-		$examples .= "Content quality example:\n";
-		$examples .= "{\n";
-		$examples .= '  "block_id": "example-1",' . "\n";
-		$examples .= '  "category": "content",' . "\n";
-		$examples .= '  "severity": "important",' . "\n";
-		$examples .= '  "title": "Cite your source",' . "\n";
-		$examples .= '  "feedback": "The statistic \'80% of users prefer...\' needs attribution. Unsourced data weakens credibility.",' . "\n";
-		$examples .= '  "suggestion": "Add source: \'According to [Study Name, Year], 80% of users prefer...\'"' . "\n";
-		$examples .= "}\n\n";
+		$examples = <<<'EOT'
+REFERENCE EXAMPLES:
+Use these as a guide for the quality, format, and tone of your feedback.
+Each item in the "feedback" array should follow this format:
 
-		$examples .= "Tone example:\n";
-		$examples .= "{\n";
-		$examples .= '  "block_id": "example-2",' . "\n";
-		$examples .= '  "category": "tone",' . "\n";
-		$examples .= '  "severity": "suggestion",' . "\n";
-		$examples .= '  "title": "Match formal tone",' . "\n";
-		$examples .= '  "feedback": "The phrase \'pretty cool feature\' is too casual for this technical document.",' . "\n";
-		$examples .= '  "suggestion": "Replace with: \'This feature significantly improves...\'"' . "\n";
-		$examples .= "}\n\n";
+Content quality example (severity: important):
+{
+  "summary": "The document has strong structure but several claims lack supporting evidence.",
+  "feedback": [
+    {
+      "block_id": "example-1",
+      "category": "content",
+      "severity": "important",
+      "title": "Cite your source",
+      "feedback": "The statistic '80% of users prefer...' needs attribution. Unsourced data weakens credibility.",
+      "suggestion": "Add source: 'According to [Study Name, Year], 80% of users prefer...'"
+    }
+  ]
+}
 
-		$examples .= "Flow example:\n";
-		$examples .= "{\n";
-		$examples .= '  "block_id": "example-3",' . "\n";
-		$examples .= '  "category": "flow",' . "\n";
-		$examples .= '  "severity": "important",' . "\n";
-		$examples .= '  "title": "Add transition",' . "\n";
-		$examples .= '  "feedback": "Abrupt topic shift between pricing and features. Readers need context.",' . "\n";
-		$examples .= '  "suggestion": "Add transition: \'Beyond pricing benefits, the feature also offers...\'"' . "\n";
-		$examples .= "}\n\n";
+Tone example (severity: suggestion):
+{
+  "summary": "Good content overall, but a few phrases break the formal tone.",
+  "feedback": [
+    {
+      "block_id": "example-2",
+      "category": "tone",
+      "severity": "suggestion",
+      "title": "Match formal tone",
+      "feedback": "The phrase 'pretty cool feature' is too casual for this technical document.",
+      "suggestion": "Replace with: 'This feature significantly improves...'"
+    }
+  ]
+}
 
-		$examples .= "Design example:\n";
-		$examples .= "{\n";
-		$examples .= '  "block_id": "example-4",' . "\n";
-		$examples .= '  "category": "design",' . "\n";
-		$examples .= '  "severity": "suggestion",' . "\n";
-		$examples .= '  "title": "Use a list for scannability",' . "\n";
-		$examples .= '  "feedback": "Five items listed in one paragraph are hard to scan.",' . "\n";
-		$examples .= '  "suggestion": "Convert to a bulleted list with one item per benefit."' . "\n";
-		$examples .= "}\n\n";
+Flow example (severity: important):
+{
+  "summary": "Content is well-written but transitions between sections need work.",
+  "feedback": [
+    {
+      "block_id": "example-3",
+      "category": "flow",
+      "severity": "important",
+      "title": "Add transition",
+      "feedback": "Abrupt topic shift between pricing and features. Readers need context.",
+      "suggestion": "Add transition: 'Beyond pricing benefits, the feature also offers...'"
+    }
+  ]
+}
 
-		$examples .= "When content is well-written, return minimal or no feedback:\n";
-		$examples .= "{\n";
-		$examples .= '  "summary": "Well-structured content with clear arguments and consistent tone.",' . "\n";
-		$examples .= '  "feedback": []' . "\n";
-		$examples .= '}';
+Design example (severity: suggestion):
+{
+  "summary": "Content reads well but formatting could improve scannability.",
+  "feedback": [
+    {
+      "block_id": "example-4",
+      "category": "design",
+      "severity": "suggestion",
+      "title": "Use a list for scannability",
+      "feedback": "Five items listed in one paragraph are hard to scan.",
+      "suggestion": "Convert to a bulleted list with one item per benefit."
+    }
+  ]
+}
 
-		return $examples;
+When content is well-written, return minimal or no feedback:
+{
+  "summary": "Well-structured content with clear arguments and consistent tone.",
+  "feedback": []
+}
+EOT;
+
+		$examples = $language_note . $examples;
+
+		/**
+		 * Filters the few-shot examples appended to the AI review prompt.
+		 *
+		 * Return an empty string to disable few-shot examples entirely.
+		 *
+		 * @param string $examples The formatted few-shot examples.
+		 * @param string $locale   The current WordPress locale.
+		 */
+		return apply_filters( 'ai_feedback_few_shot_examples', $examples, $locale );
 	}
 }

--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -63,36 +63,36 @@ class Prompt_Builder {
 		}
 
 		// Construct the full prompt.
-		$prompt  = 'Please review the following document and provide actionable editorial feedback.' . "\n\n";
-		$prompt .= 'DOCUMENT TITLE: ' . $options['post_title'] . "\n\n";
-		$prompt .= "DOCUMENT BLOCKS:\n" . $document_blocks . "\n\n";
-		$prompt .= "FOCUS AREAS:\n" . $focus_instructions . "\n\n";
-		$prompt .= "TARGET TONE:\n" . $tone_guidance;
-		$prompt .= $language_instruction;
-		$prompt .= $continuation_instructions . "\n\n";
-		$prompt .= $this->get_block_type_instructions() . "\n\n";
-		$prompt .= "INSTRUCTIONS:\n";
-		$prompt .= "- Provide specific, actionable feedback for each issue you identify\n";
-		$prompt .= "- Reference blocks by their block_id (the unique identifier shown for each block)\n";
-		$prompt .= "- Prioritize the most impactful suggestions\n";
-		$prompt .= "- Be encouraging but honest\n";
-		$prompt .= "- Each feedback item should explain WHY it matters and HOW to improve it\n";
-		$prompt .= "- Include an overall summary of the document quality\n\n";
-		$prompt .= "OUTPUT FORMAT:\n";
-		$prompt .= 'Return your response as a JSON object with two properties: "summary" and "feedback".' . "\n\n";
-		$prompt .= "{\n";
-		$prompt .= '  "summary": "A one-paragraph overall assessment of the document (max 300 chars). Include the total number of notes, overall tone assessment, and key improvement areas.",' . "\n";
-		$prompt .= '  "feedback": [' . "\n";
-		$prompt .= "    {\n";
-		$prompt .= '      "block_id": "abc123-def456",' . "\n";
-		$prompt .= '      "category": "content|tone|flow|design",' . "\n";
-		$prompt .= '      "severity": "suggestion|important|critical",' . "\n";
-		$prompt .= '      "title": "Brief title (max 50 chars)",' . "\n";
-		$prompt .= '      "feedback": "Detailed explanation of the issue and why it matters (max 200 chars)",' . "\n";
-		$prompt .= '      "suggestion": "Specific action to take (max 200 chars, optional)"' . "\n";
-		$prompt .= "    }\n";
-		$prompt .= "  ]\n";
-		$prompt .= "}\n\n";
+		$prompt            = 'Please review the following document and provide actionable editorial feedback.' . "\n\n";
+		$prompt           .= 'DOCUMENT TITLE: ' . $options['post_title'] . "\n\n";
+		$prompt           .= "DOCUMENT BLOCKS:\n" . $document_blocks . "\n\n";
+		$prompt           .= "FOCUS AREAS:\n" . $focus_instructions . "\n\n";
+		$prompt           .= "TARGET TONE:\n" . $tone_guidance;
+		$prompt           .= $language_instruction;
+		$prompt           .= $continuation_instructions . "\n\n";
+		$prompt           .= $this->get_block_type_instructions() . "\n\n";
+		$prompt           .= "INSTRUCTIONS:\n";
+		$prompt           .= "- Provide specific, actionable feedback for each issue you identify\n";
+		$prompt           .= "- Reference blocks by their block_id (the unique identifier shown for each block)\n";
+		$prompt           .= "- Prioritize the most impactful suggestions\n";
+		$prompt           .= "- Be encouraging but honest\n";
+		$prompt           .= "- Each feedback item should explain WHY it matters and HOW to improve it\n";
+		$prompt           .= "- Include an overall summary of the document quality\n\n";
+		$prompt           .= "OUTPUT FORMAT:\n";
+		$prompt           .= 'Return your response as a JSON object with two properties: "summary" and "feedback".' . "\n\n";
+		$prompt           .= "{\n";
+		$prompt           .= '  "summary": "A one-paragraph overall assessment of the document (max 300 chars). Include the total number of notes, overall tone assessment, and key improvement areas.",' . "\n";
+		$prompt           .= '  "feedback": [' . "\n";
+		$prompt           .= "    {\n";
+		$prompt           .= '      "block_id": "abc123-def456",' . "\n";
+		$prompt           .= '      "category": "content|tone|flow|design",' . "\n";
+		$prompt           .= '      "severity": "suggestion|important|critical",' . "\n";
+		$prompt           .= '      "title": "Brief title (max 50 chars)",' . "\n";
+		$prompt           .= '      "feedback": "Detailed explanation of the issue and why it matters (max 200 chars)",' . "\n";
+		$prompt           .= '      "suggestion": "Specific action to take (max 200 chars, optional)"' . "\n";
+		$prompt           .= "    }\n";
+		$prompt           .= "  ]\n";
+		$prompt           .= "}\n\n";
 		$few_shot_examples = $this->get_few_shot_examples( $options['locale'] ?? 'en_US' );
 
 		// Only append examples if the base prompt is already under the character

--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -93,6 +93,7 @@ class Prompt_Builder {
 		$prompt .= "    }\n";
 		$prompt .= "  ]\n";
 		$prompt .= "}\n\n";
+		$prompt .= $this->get_few_shot_examples() . "\n\n";
 		$prompt .= "IMPORTANT:\n";
 		$prompt .= '- The "block_id" must exactly match one of the block IDs provided in the document' . "\n";
 		$prompt .= "- Return ONLY valid JSON, no additional text or explanation\n";
@@ -409,5 +410,66 @@ class Prompt_Builder {
 
 		// Default to English.
 		return "\n\n## LANGUAGE\n\nProvide feedback in English.\n";
+	}
+
+	/**
+	 * Get few-shot examples to guide consistent AI output.
+	 *
+	 * Provides reference examples for each feedback category and severity
+	 * level so the AI produces consistently formatted, high-quality feedback.
+	 *
+	 * @return string Few-shot examples for the prompt.
+	 */
+	private function get_few_shot_examples(): string {
+		$examples  = "REFERENCE EXAMPLES:\n";
+		$examples .= "Use these as a guide for the quality, format, and tone of your feedback:\n\n";
+
+		$examples .= "Content quality example:\n";
+		$examples .= "{\n";
+		$examples .= '  "block_id": "example-1",' . "\n";
+		$examples .= '  "category": "content",' . "\n";
+		$examples .= '  "severity": "important",' . "\n";
+		$examples .= '  "title": "Cite your source",' . "\n";
+		$examples .= '  "feedback": "The statistic \'80% of users prefer...\' needs attribution. Unsourced data weakens credibility.",' . "\n";
+		$examples .= '  "suggestion": "Add source: \'According to [Study Name, Year], 80% of users prefer...\'"' . "\n";
+		$examples .= "}\n\n";
+
+		$examples .= "Tone example:\n";
+		$examples .= "{\n";
+		$examples .= '  "block_id": "example-2",' . "\n";
+		$examples .= '  "category": "tone",' . "\n";
+		$examples .= '  "severity": "suggestion",' . "\n";
+		$examples .= '  "title": "Match formal tone",' . "\n";
+		$examples .= '  "feedback": "The phrase \'pretty cool feature\' is too casual for this technical document.",' . "\n";
+		$examples .= '  "suggestion": "Replace with: \'This feature significantly improves...\'"' . "\n";
+		$examples .= "}\n\n";
+
+		$examples .= "Flow example:\n";
+		$examples .= "{\n";
+		$examples .= '  "block_id": "example-3",' . "\n";
+		$examples .= '  "category": "flow",' . "\n";
+		$examples .= '  "severity": "important",' . "\n";
+		$examples .= '  "title": "Add transition",' . "\n";
+		$examples .= '  "feedback": "Abrupt topic shift between pricing and features. Readers need context.",' . "\n";
+		$examples .= '  "suggestion": "Add transition: \'Beyond pricing benefits, the feature also offers...\'"' . "\n";
+		$examples .= "}\n\n";
+
+		$examples .= "Design example:\n";
+		$examples .= "{\n";
+		$examples .= '  "block_id": "example-4",' . "\n";
+		$examples .= '  "category": "design",' . "\n";
+		$examples .= '  "severity": "suggestion",' . "\n";
+		$examples .= '  "title": "Use a list for scannability",' . "\n";
+		$examples .= '  "feedback": "Five items listed in one paragraph are hard to scan.",' . "\n";
+		$examples .= '  "suggestion": "Convert to a bulleted list with one item per benefit."' . "\n";
+		$examples .= "}\n\n";
+
+		$examples .= "When content is well-written, return minimal or no feedback:\n";
+		$examples .= "{\n";
+		$examples .= '  "summary": "Well-structured content with clear arguments and consistent tone.",' . "\n";
+		$examples .= '  "feedback": []' . "\n";
+		$examples .= '}';
+
+		return $examples;
 	}
 }

--- a/tests/php/PromptBuilderTest.php
+++ b/tests/php/PromptBuilderTest.php
@@ -276,4 +276,74 @@ class PromptBuilderTest extends TestCase {
 		$this->assertGreaterThan( $block_type_pos, $instructions_pos );
 		$this->assertGreaterThan( $instructions_pos, $output_pos );
 	}
+
+	/**
+	 * Test few-shot examples contain all four categories.
+	 */
+	public function test_few_shot_examples_cover_all_categories(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples' );
+
+		$this->assertStringContainsString( '"category": "content"', $examples );
+		$this->assertStringContainsString( '"category": "tone"', $examples );
+		$this->assertStringContainsString( '"category": "flow"', $examples );
+		$this->assertStringContainsString( '"category": "design"', $examples );
+	}
+
+	/**
+	 * Test few-shot examples include both severity levels.
+	 */
+	public function test_few_shot_examples_cover_severities(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples' );
+
+		$this->assertStringContainsString( '"severity": "important"', $examples );
+		$this->assertStringContainsString( '"severity": "suggestion"', $examples );
+	}
+
+	/**
+	 * Test few-shot examples include good content case.
+	 */
+	public function test_few_shot_examples_include_good_content_case(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples' );
+
+		$this->assertStringContainsString( '"feedback": []', $examples );
+	}
+
+	/**
+	 * Test few-shot examples are included in the full prompt.
+	 */
+	public function test_few_shot_examples_in_prompt(): void {
+		$blocks = array(
+			array(
+				'clientId' => 'test-1',
+				'name'     => 'core/paragraph',
+				'content'  => 'Test content.',
+			),
+		);
+
+		$prompt = $this->builder->build_review_prompt( $blocks );
+
+		$this->assertStringContainsString( 'REFERENCE EXAMPLES:', $prompt );
+	}
+
+	/**
+	 * Test few-shot examples appear between OUTPUT FORMAT and IMPORTANT.
+	 */
+	public function test_few_shot_examples_position(): void {
+		$blocks = array(
+			array(
+				'clientId' => 'test-1',
+				'name'     => 'core/paragraph',
+				'content'  => 'Test content.',
+			),
+		);
+
+		$prompt = $this->builder->build_review_prompt( $blocks );
+
+		$output_pos   = strpos( $prompt, 'OUTPUT FORMAT:' );
+		$examples_pos = strpos( $prompt, 'REFERENCE EXAMPLES:' );
+		$important_pos = strpos( $prompt, 'IMPORTANT:' );
+
+		$this->assertGreaterThan( $output_pos, $examples_pos );
+		$this->assertGreaterThan( $examples_pos, $important_pos );
+	}
 }

--- a/tests/php/PromptBuilderTest.php
+++ b/tests/php/PromptBuilderTest.php
@@ -270,11 +270,18 @@ class PromptBuilderTest extends TestCase {
 		$instructions_pos = strpos( $prompt, 'INSTRUCTIONS:' );
 		$output_pos       = strpos( $prompt, 'OUTPUT FORMAT:' );
 
-		$this->assertGreaterThan( $doc_pos, $focus_pos );
-		$this->assertGreaterThan( $focus_pos, $tone_pos );
-		$this->assertGreaterThan( $tone_pos, $block_type_pos );
-		$this->assertGreaterThan( $block_type_pos, $instructions_pos );
-		$this->assertGreaterThan( $instructions_pos, $output_pos );
+		$this->assertNotFalse( $doc_pos, 'DOCUMENT BLOCKS section must exist' );
+		$this->assertNotFalse( $focus_pos, 'FOCUS AREAS section must exist' );
+		$this->assertNotFalse( $tone_pos, 'TARGET TONE section must exist' );
+		$this->assertNotFalse( $block_type_pos, 'BLOCK-TYPE SPECIFIC GUIDANCE section must exist' );
+		$this->assertNotFalse( $instructions_pos, 'INSTRUCTIONS section must exist' );
+		$this->assertNotFalse( $output_pos, 'OUTPUT FORMAT section must exist' );
+
+		$this->assertLessThan( $focus_pos, $doc_pos );
+		$this->assertLessThan( $tone_pos, $focus_pos );
+		$this->assertLessThan( $block_type_pos, $tone_pos );
+		$this->assertLessThan( $instructions_pos, $block_type_pos );
+		$this->assertLessThan( $output_pos, $instructions_pos );
 	}
 
 	/**
@@ -309,6 +316,16 @@ class PromptBuilderTest extends TestCase {
 	}
 
 	/**
+	 * Test few-shot examples wrap items in the full response structure.
+	 */
+	public function test_few_shot_examples_show_full_response_structure(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples' );
+
+		$this->assertStringContainsString( '"summary":', $examples );
+		$this->assertStringContainsString( '"feedback": [', $examples );
+	}
+
+	/**
 	 * Test few-shot examples are included in the full prompt.
 	 */
 	public function test_few_shot_examples_in_prompt(): void {
@@ -339,11 +356,52 @@ class PromptBuilderTest extends TestCase {
 
 		$prompt = $this->builder->build_review_prompt( $blocks );
 
-		$output_pos   = strpos( $prompt, 'OUTPUT FORMAT:' );
-		$examples_pos = strpos( $prompt, 'REFERENCE EXAMPLES:' );
+		$output_pos    = strpos( $prompt, 'OUTPUT FORMAT:' );
+		$examples_pos  = strpos( $prompt, 'REFERENCE EXAMPLES:' );
 		$important_pos = strpos( $prompt, 'IMPORTANT:' );
 
-		$this->assertGreaterThan( $output_pos, $examples_pos );
-		$this->assertGreaterThan( $examples_pos, $important_pos );
+		$this->assertNotFalse( $output_pos, 'OUTPUT FORMAT section must exist' );
+		$this->assertNotFalse( $examples_pos, 'REFERENCE EXAMPLES section must exist' );
+		$this->assertNotFalse( $important_pos, 'IMPORTANT section must exist' );
+
+		$this->assertLessThan( $examples_pos, $output_pos );
+		$this->assertLessThan( $important_pos, $examples_pos );
+	}
+
+	/**
+	 * Test few-shot examples include language note for non-English locales.
+	 */
+	public function test_few_shot_examples_locale_note_for_non_english(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples', array( 'es_ES' ) );
+
+		$this->assertStringContainsString( 'language specified in the LANGUAGE section', $examples );
+	}
+
+	/**
+	 * Test few-shot examples omit language note for English locale.
+	 */
+	public function test_few_shot_examples_no_locale_note_for_english(): void {
+		$examples = $this->invoke_private( 'get_few_shot_examples', array( 'en_US' ) );
+
+		$this->assertStringNotContainsString( 'language specified in the LANGUAGE section', $examples );
+	}
+
+	/**
+	 * Test few-shot examples are skipped when prompt is too long.
+	 */
+	public function test_few_shot_examples_skipped_for_long_prompts(): void {
+		// Create enough blocks to push the prompt over the 12000-char budget.
+		$blocks = array();
+		for ( $i = 0; $i < 10; $i++ ) {
+			$blocks[] = array(
+				'clientId' => "long-$i",
+				'name'     => 'core/paragraph',
+				'content'  => str_repeat( 'Word ', 400 ),
+			);
+		}
+
+		$prompt = $this->builder->build_review_prompt( $blocks );
+
+		$this->assertStringNotContainsString( 'REFERENCE EXAMPLES:', $prompt );
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'get_locale' ) ) {
 }
 
 if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( $hook_name, $value, ...$args ) {
+	function apply_filters( $_hook_name, $value, ...$args ) {
 		return $value;
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -21,6 +21,19 @@ if (! defined('ABSPATH') ) {
     define('ABSPATH', dirname(__DIR__, 2) . '/');
 }
 
+// Mock WordPress core functions.
+if ( ! function_exists( 'get_locale' ) ) {
+	function get_locale() {
+		return 'en_US';
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook_name, $value ) {
+		return $value;
+	}
+}
+
 // Mock WordPress translation functions.
 if (! function_exists('__') ) {
     function __( $text, $domain = 'default' )

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'get_locale' ) ) {
 }
 
 if ( ! function_exists( 'apply_filters' ) ) {
-	function apply_filters( $hook_name, $value ) {
+	function apply_filters( $hook_name, $value, ...$args ) {
 		return $value;
 	}
 }


### PR DESCRIPTION
## Summary
- Adds reference examples in the prompt for each feedback category (content, tone, flow, design)
- Includes examples for both `important` and `suggestion` severity levels
- Includes a "good content" example showing empty feedback array for well-written documents
- 5 new unit tests covering categories, severities, placement, and prompt integration

## Benefits
- More consistent output format across different AI models
- Higher quality feedback with clear expectations
- Reduced variation in response structure

## Test plan
- [ ] `composer run phpcs` passes
- [ ] `./vendor/bin/phpunit tests/php/PromptBuilderTest.php` — all 22 tests pass
- [ ] Manual: review a document and verify feedback matches the example format

Fixes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a locale-aware "REFERENCE EXAMPLES" few-shot section to review prompts, inserted between output format and final instructions when a character budget allows, with a filter hook to override or disable it.

* **Tests**
  * Added tests validating example categories, severities, response structure, insertion position, locale-note behavior, and skipping when prompts exceed the length budget.

* **Chores**
  * Added test bootstrap helpers to provide locale and filter behavior during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->