### PR TITLE
Fix JS and CSS lint errors blocking CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+	extends: ['plugin:@wordpress/eslint-plugin/recommended'],
+	root: true,
+	rules: {
+		'jsdoc/no-undefined-types': [
+			'error',
+			{ definedTypes: ['JSX', 'Element'] },
+		],
+	},
+	overrides: [
+		{
+			files: ['tests/e2e/**/*.js'],
+			rules: {
+				'import/no-extraneous-dependencies': 'off',
+			},
+		},
+	],
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -408,6 +408,7 @@ $ai-feedback-text-muted: #595959;
 		outline-offset: -2px;
 	}
 
+	/* stylelint-disable-next-line selector-class-pattern */
 	.components-card__body {
 		padding: 12px;
 	}
@@ -465,11 +466,13 @@ $ai-feedback-text-muted: #595959;
 		outline-offset: -2px;
 	}
 
+	/* stylelint-disable-next-line selector-class-pattern */
 	.components-card__header {
 		padding: 12px;
 		border-bottom: 1px solid #e0e0e0;
 	}
 
+	/* stylelint-disable-next-line selector-class-pattern */
 	.components-card__body {
 		padding: 12px;
 	}
@@ -571,6 +574,7 @@ $ai-feedback-text-muted: #595959;
 	padding-top: 16px;
 	border-top: 1px solid #e0e0e0;
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	h4 {
 		font-size: 14px;
 		font-weight: 600;


### PR DESCRIPTION
Resolves lint failures on main that have been blocking CI across all open PRs (including Dependabot bumps #123, #126, #127, #128 and the Playwright infra PR #77).

## Changes

**JavaScript (`.eslintrc.js`)**
- New minimal project config extending `@wordpress/eslint-plugin/recommended`
- Adds `JSX` and `Element` to `jsdoc/no-undefined-types` `definedTypes` so component `@return` annotations stop reporting as undefined
- Disables `import/no-extraneous-dependencies` under `tests/e2e/**` where `@wordpress/e2e-test-utils-playwright` is consumed transitively via `@wordpress/scripts`

**SCSS (`src/index.scss`)**
- Adds `stylelint-disable-next-line selector-class-pattern` for three `.components-card__header/__body` selectors that target WP core component BEM classes
- Adds `stylelint-disable-next-line no-descending-specificity` for the `h4` rule under `.feedback-details`

## Verification

```
npm run lint:js   # clean
npm run lint:css  # clean
```

## Test plan

- [ ] CI lint jobs pass on this PR
- [ ] After merge, re-run CI on #77 and #123/#126/#127/#128 — lint should no longer fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ESLint configuration implementing WordPress recommended rules with enhanced JSDoc type checking
  * Configured linting exceptions for test files
  * Added stylelint suppressions to stylesheet configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->