### PR TITLE
Add Reply_Detector for Phase 4 conversation loop

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -55,6 +55,13 @@ class Plugin {
 	private ?Health_Controller $health_controller = null;
 
 	/**
+	 * Reply detector instance.
+	 *
+	 * @var Reply_Detector|null
+	 */
+	private ?Reply_Detector $reply_detector = null;
+
+	/**
 	 * Get plugin instance.
 	 *
 	 * @return Plugin
@@ -91,6 +98,9 @@ class Plugin {
 
 		// Add custom avatar for AI Feedback comments/notes.
 		add_filter( 'pre_get_avatar_data', array( $this, 'filter_ai_feedback_avatar' ), 10, 2 );
+
+		$this->reply_detector = new Reply_Detector();
+		$this->reply_detector->register();
 	}
 
 	/**

--- a/includes/class-reply-detector.php
+++ b/includes/class-reply-detector.php
@@ -17,10 +17,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Detects replies to AI Feedback notes.
  *
- * A "reply" is any block_comment whose parent is an AI-authored note
- * (a comment with `ai_feedback` meta set to '1') AND which was not
- * itself authored by AI Feedback — the latter check prevents our own
- * generated replies from re-triggering detection.
+ * A "reply" is any `note`-type comment whose parent is an AI-authored
+ * note (a comment with `ai_feedback` meta set to '1') AND which was
+ * not itself authored by AI Feedback — the latter check prevents our
+ * own generated replies from re-triggering detection.
+ *
+ * WordPress 6.9+ stores block-level notes as comments with
+ * `comment_type = 'note'` (see Notes_Manager::create_note()).
  */
 class Reply_Detector {
 
@@ -47,8 +50,8 @@ class Reply_Detector {
 	 * @param object $comment    Comment object (WP_Comment in production).
 	 */
 	public function maybe_dispatch_reply( int $comment_id, $comment ): void {
-		// Only care about block-level comments.
-		if ( 'block_comment' !== ( $comment->comment_type ?? '' ) ) {
+		// Only care about block-level notes.
+		if ( 'note' !== ( $comment->comment_type ?? '' ) ) {
 			return;
 		}
 

--- a/includes/class-reply-detector.php
+++ b/includes/class-reply-detector.php
@@ -46,8 +46,8 @@ class Reply_Detector {
 	 * Inspect a newly inserted comment and dispatch the reply action when
 	 * it is a user reply to an AI Feedback note.
 	 *
-	 * @param int    $comment_id Inserted comment ID.
-	 * @param object $comment    Comment object (WP_Comment in production).
+	 * @param int                   $comment_id Inserted comment ID.
+	 * @param \WP_Comment|\stdClass $comment    Comment object (stdClass accepted for unit tests).
 	 */
 	public function maybe_dispatch_reply( int $comment_id, $comment ): void {
 		// Only care about block-level notes.
@@ -73,8 +73,17 @@ class Reply_Detector {
 			return;
 		}
 
-		$post_id  = (int) ( $comment->comment_post_ID ?? 0 );
-		$block_id = (string) get_comment_meta( $parent_id, 'block_id', true );
+		$post_id = (int) ( $comment->comment_post_ID ?? 0 );
+		if ( $post_id <= 0 ) {
+			// Comment without a valid post association — nothing to route.
+			return;
+		}
+
+		$block_id = sanitize_text_field( (string) get_comment_meta( $parent_id, 'block_id', true ) );
+		if ( '' === $block_id ) {
+			// Parent note has no block association; consumers cannot resolve the target.
+			return;
+		}
 
 		do_action( self::ACTION_REPLY_RECEIVED, $comment_id, $parent_id, $post_id, $block_id );
 	}

--- a/includes/class-reply-detector.php
+++ b/includes/class-reply-detector.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Reply Detector
+ *
+ * Detects user replies to AI Feedback notes and dispatches a dedicated
+ * action for the Reply Service to handle asynchronously.
+ *
+ * @package AI_Feedback
+ */
+
+namespace AI_Feedback;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Detects replies to AI Feedback notes.
+ *
+ * A "reply" is any block_comment whose parent is an AI-authored note
+ * (a comment with `ai_feedback` meta set to '1') AND which was not
+ * itself authored by AI Feedback — the latter check prevents our own
+ * generated replies from re-triggering detection.
+ */
+class Reply_Detector {
+
+	/**
+	 * Action fired when a user reply to an AI Feedback note is detected.
+	 *
+	 * Args: int $comment_id, int $parent_comment_id, int $post_id, string $block_id.
+	 */
+	public const ACTION_REPLY_RECEIVED = 'ai_feedback_note_reply_received';
+
+	/**
+	 * Register hooks.
+	 */
+	public function register(): void {
+		// wp_insert_comment fires with ( int $comment_id, WP_Comment $comment ).
+		add_action( 'wp_insert_comment', array( $this, 'maybe_dispatch_reply' ), 10, 2 );
+	}
+
+	/**
+	 * Inspect a newly inserted comment and dispatch the reply action when
+	 * it is a user reply to an AI Feedback note.
+	 *
+	 * @param int    $comment_id Inserted comment ID.
+	 * @param object $comment    Comment object (WP_Comment in production).
+	 */
+	public function maybe_dispatch_reply( int $comment_id, $comment ): void {
+		// Only care about block-level comments.
+		if ( 'block_comment' !== ( $comment->comment_type ?? '' ) ) {
+			return;
+		}
+
+		$parent_id = (int) ( $comment->comment_parent ?? 0 );
+		if ( $parent_id <= 0 ) {
+			// Top-level note, not a reply.
+			return;
+		}
+
+		// Ignore replies authored by AI Feedback itself.
+		$is_ai_reply = (bool) get_comment_meta( $comment_id, 'ai_feedback', true );
+		if ( $is_ai_reply ) {
+			return;
+		}
+
+		// Parent must be an AI Feedback note.
+		$parent_is_ai = (bool) get_comment_meta( $parent_id, 'ai_feedback', true );
+		if ( ! $parent_is_ai ) {
+			return;
+		}
+
+		$post_id  = (int) ( $comment->comment_post_ID ?? 0 );
+		$block_id = (string) get_comment_meta( $parent_id, 'block_id', true );
+
+		do_action( self::ACTION_REPLY_RECEIVED, $comment_id, $parent_id, $post_id, $block_id );
+	}
+}

--- a/tests/php/ReplyDetectorTest.php
+++ b/tests/php/ReplyDetectorTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Tests for Reply_Detector.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Reply_Detector;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-detector.php';
+
+/**
+ * Test cases for Reply_Detector.
+ */
+class ReplyDetectorTest extends TestCase {
+
+	/**
+	 * Detector instance.
+	 */
+	private Reply_Detector $detector;
+
+	/**
+	 * Set up global mocks for comment meta and action dispatch.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->detector = new Reply_Detector();
+
+		$GLOBALS['test_comment_meta']     = array();
+		$GLOBALS['test_dispatched_calls'] = array();
+
+		if ( ! function_exists( 'AI_Feedback\\Tests\\__register_mocks' ) ) {
+			require_once __DIR__ . '/reply-detector-mocks.php';
+		}
+	}
+
+	/**
+	 * Clean up globals after each test.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['test_comment_meta'], $GLOBALS['test_dispatched_calls'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * A user reply to an AI note dispatches the action.
+	 */
+	public function test_user_reply_to_ai_note_dispatches_action(): void {
+		// Parent (comment 100) is an AI Feedback note.
+		$GLOBALS['test_comment_meta'][100] = array(
+			'ai_feedback' => '1',
+			'block_id'    => 'abc-123',
+		);
+
+		$reply = (object) array(
+			'comment_type'    => 'block_comment',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $reply );
+
+		$dispatched = $GLOBALS['test_dispatched_calls'];
+		$this->assertCount( 1, $dispatched );
+		$this->assertSame( Reply_Detector::ACTION_REPLY_RECEIVED, $dispatched[0]['hook'] );
+		$this->assertSame( array( 200, 100, 42, 'abc-123' ), $dispatched[0]['args'] );
+	}
+
+	/**
+	 * A reply to a non-AI note is ignored.
+	 */
+	public function test_reply_to_non_ai_note_is_ignored(): void {
+		// Parent has no ai_feedback meta.
+		$GLOBALS['test_comment_meta'][100] = array();
+
+		$reply = (object) array(
+			'comment_type'    => 'block_comment',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $reply );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+
+	/**
+	 * A top-level (non-reply) block comment is ignored.
+	 */
+	public function test_top_level_comment_is_ignored(): void {
+		$comment = (object) array(
+			'comment_type'    => 'block_comment',
+			'comment_parent'  => 0,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $comment );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+
+	/**
+	 * A reply authored by AI Feedback itself does not re-trigger detection.
+	 */
+	public function test_ai_authored_reply_is_ignored(): void {
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+		// The reply itself is flagged as ai_feedback — avoids loops.
+		$GLOBALS['test_comment_meta'][200] = array( 'ai_feedback' => '1' );
+
+		$reply = (object) array(
+			'comment_type'    => 'block_comment',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $reply );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+
+	/**
+	 * A non-block-comment reply (e.g. a regular post comment) is ignored.
+	 */
+	public function test_non_block_comment_is_ignored(): void {
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+
+		$comment = (object) array(
+			'comment_type'    => 'comment',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $comment );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+}

--- a/tests/php/ReplyDetectorTest.php
+++ b/tests/php/ReplyDetectorTest.php
@@ -138,4 +138,44 @@ class ReplyDetectorTest extends TestCase {
 
 		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
 	}
+
+	/**
+	 * A reply whose parent has no block_id meta is ignored — consumers
+	 * cannot resolve the target block, so dispatching with an empty
+	 * block_id is worse than not dispatching at all.
+	 */
+	public function test_reply_without_parent_block_id_is_ignored(): void {
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+
+		$reply = (object) array(
+			'comment_type'    => 'note',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 42,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $reply );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+
+	/**
+	 * A comment without a valid post association (post_id <= 0) is ignored.
+	 */
+	public function test_reply_with_invalid_post_id_is_ignored(): void {
+		$GLOBALS['test_comment_meta'][100] = array(
+			'ai_feedback' => '1',
+			'block_id'    => 'abc-123',
+		);
+
+		$reply = (object) array(
+			'comment_type'    => 'note',
+			'comment_parent'  => 100,
+			'comment_post_ID' => 0,
+		);
+
+		$this->detector->maybe_dispatch_reply( 200, $reply );
+
+		$this->assertCount( 0, $GLOBALS['test_dispatched_calls'] );
+	}
+
 }

--- a/tests/php/ReplyDetectorTest.php
+++ b/tests/php/ReplyDetectorTest.php
@@ -57,7 +57,7 @@ class ReplyDetectorTest extends TestCase {
 		);
 
 		$reply = (object) array(
-			'comment_type'    => 'block_comment',
+			'comment_type'    => 'note',
 			'comment_parent'  => 100,
 			'comment_post_ID' => 42,
 		);
@@ -78,7 +78,7 @@ class ReplyDetectorTest extends TestCase {
 		$GLOBALS['test_comment_meta'][100] = array();
 
 		$reply = (object) array(
-			'comment_type'    => 'block_comment',
+			'comment_type'    => 'note',
 			'comment_parent'  => 100,
 			'comment_post_ID' => 42,
 		);
@@ -93,7 +93,7 @@ class ReplyDetectorTest extends TestCase {
 	 */
 	public function test_top_level_comment_is_ignored(): void {
 		$comment = (object) array(
-			'comment_type'    => 'block_comment',
+			'comment_type'    => 'note',
 			'comment_parent'  => 0,
 			'comment_post_ID' => 42,
 		);
@@ -112,7 +112,7 @@ class ReplyDetectorTest extends TestCase {
 		$GLOBALS['test_comment_meta'][200] = array( 'ai_feedback' => '1' );
 
 		$reply = (object) array(
-			'comment_type'    => 'block_comment',
+			'comment_type'    => 'note',
 			'comment_parent'  => 100,
 			'comment_post_ID' => 42,
 		);
@@ -125,7 +125,7 @@ class ReplyDetectorTest extends TestCase {
 	/**
 	 * A non-block-comment reply (e.g. a regular post comment) is ignored.
 	 */
-	public function test_non_block_comment_is_ignored(): void {
+	public function test_non_note_is_ignored(): void {
 		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
 
 		$comment = (object) array(

--- a/tests/php/reply-detector-mocks.php
+++ b/tests/php/reply-detector-mocks.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Mocks for Reply_Detector tests.
+ *
+ * Declared in the root namespace because Reply_Detector calls
+ * unqualified WordPress functions (get_comment_meta, do_action), and
+ * PHP resolves those against the global namespace when not found in
+ * the caller's namespace.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace {
+
+	if ( ! function_exists( 'get_comment_meta' ) ) {
+		/**
+		 * Minimal get_comment_meta mock.
+		 *
+		 * Reads from $GLOBALS['test_comment_meta'][ $comment_id ][ $key ].
+		 * Returns '' when unset, matching WP's single=true behavior.
+		 *
+		 * @param int    $comment_id Comment ID.
+		 * @param string $key        Meta key.
+		 * @param bool   $single     Whether to return a single value (ignored).
+		 * @return mixed
+		 */
+		function get_comment_meta( $comment_id, $key = '', $single = false ) {
+			$store = $GLOBALS['test_comment_meta'] ?? array();
+			$meta  = $store[ $comment_id ] ?? array();
+
+			if ( '' === $key ) {
+				return $meta;
+			}
+
+			return $meta[ $key ] ?? '';
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		/**
+		 * Minimal do_action mock.
+		 *
+		 * Appends each dispatch to $GLOBALS['test_dispatched_calls'] as
+		 * `array( 'hook' => string, 'args' => array )` so tests can
+		 * assert on hook name and arguments.
+		 *
+		 * @param string $hook Hook name.
+		 * @param mixed  ...$args Hook arguments.
+		 */
+		function do_action( $hook, ...$args ) {
+			$GLOBALS['test_dispatched_calls'][] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+		}
+	}
+}
+
+namespace AI_Feedback\Tests {
+	/**
+	 * Marker so the test file can avoid re-requiring this file.
+	 */
+	function __register_mocks(): void {}
+}


### PR DESCRIPTION
## Summary

Kicks off Phase 4 (Conversation Loop) with the smallest vertical slice: detect user replies to AI Feedback notes and dispatch a dedicated action. No AI calls or UI yet — those land in #132–#134.

- New `Reply_Detector` class hooks `wp_insert_comment`
- Filters to `comment_type = block_comment` with a parent that carries `ai_feedback` meta
- Skips replies authored by AI Feedback itself (checks `ai_feedback` meta on the reply) so our own responses can't re-trigger the loop
- Fires `ai_feedback_note_reply_received` with reply id, parent note id, post id, and block id
- Wired into `Plugin::init_hooks()`

## Tests

5 new PHPUnit cases in `tests/php/ReplyDetectorTest.php`:
- Reply to AI note → dispatches action with correct args
- Reply to non-AI note → ignored
- Top-level comment (no parent) → ignored
- AI-authored reply → ignored (loop safety)
- Non-\`block_comment\` type → ignored

Mocks for `get_comment_meta` and `do_action` live in the root namespace (`tests/php/reply-detector-mocks.php`) so PHP resolves the unqualified calls in `Reply_Detector`.

## Verification

```
./vendor/bin/phpunit --bootstrap tests/php/bootstrap.php tests/php/ReplyDetectorTest.php
OK (5 tests, 7 assertions)

./vendor/bin/phpcs --standard=WordPress includes/
exit: 0

./vendor/bin/phpstan analyze --memory-limit 1G includes/
No errors
```

## Why draft

Keeping this as draft until the follow-up PRs for #132 (Reply Service) and #133 (async processing) are scoped — the action contract (`ai_feedback_note_reply_received` + its four args) is the public interface those will consume, so reviewer input on that shape is the main thing I'd like feedback on before this lands.

## Test plan
- [ ] Install WP 6.9 with the Notes/block comments feature and this plugin
- [ ] Run a review to create an AI note on a block
- [ ] Reply to the note as a user — confirm action fires (temporary debug log or `did_action()` probe)
- [ ] Reply to a non-AI block comment — confirm no action fires

Part of #131 

---
**Next in stack:** [#138](https://github.com/adamsilverstein/ai-feedback/pull/138) (Reply_Service) is stacked on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reply detection that recognizes when a user responds to an AI feedback note and triggers the plugin workflow for handling such replies.

* **Tests**
  * Added comprehensive unit tests and test helpers to validate reply detection behavior, edge cases (non-feedback, top-level, AI-authored, missing data), and ensured proper dispatching when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->