### PR TITLE
Add Reply_Service for Phase 4 conversation loop

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -62,6 +62,13 @@ class Plugin {
 	private ?Reply_Detector $reply_detector = null;
 
 	/**
+	 * Reply service instance.
+	 *
+	 * @var Reply_Service|null
+	 */
+	private ?Reply_Service $reply_service = null;
+
+	/**
 	 * Get plugin instance.
 	 *
 	 * @return Plugin
@@ -101,6 +108,9 @@ class Plugin {
 
 		$this->reply_detector = new Reply_Detector();
 		$this->reply_detector->register();
+
+		$this->reply_service = new Reply_Service();
+		$this->reply_service->register();
 	}
 
 	/**

--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -521,4 +521,118 @@ EOT;
 		 */
 		return apply_filters( 'ai_feedback_few_shot_examples', $examples, $locale );
 	}
+
+	/**
+	 * Build a prompt for replying to a user comment on an AI feedback note.
+	 *
+	 * Unlike `build_review_prompt()`, which asks the AI to produce structured
+	 * JSON feedback across the whole document, this method asks for a single
+	 * conversational reply scoped to one block and one note thread.
+	 *
+	 * @param  array $context {
+	 *     Reply context.
+	 *
+	 *     @type string $block_content     The raw content of the block being discussed.
+	 *     @type string $block_type        Optional. The block type (e.g. `core/paragraph`).
+	 *     @type string $original_feedback The original AI feedback text on this block.
+	 *     @type string $original_category Optional. Category of the original feedback (content|tone|flow|design).
+	 *     @type string $original_severity Optional. Severity of the original feedback (suggestion|important|critical).
+	 *     @type array  $thread             Prior replies in chronological order. Each entry:
+	 *                                      { string $author, string $content, bool $is_ai }.
+	 *     @type string $user_reply        The new user reply to respond to.
+	 *     @type string $target_tone       Optional. Target tone to preserve (default: professional).
+	 *     @type string $locale            Optional. Locale for the reply.
+	 * }
+	 * @return string The constructed prompt.
+	 */
+	public function build_reply_prompt( array $context ): string {
+		$block_content     = (string) ( $context['block_content'] ?? '' );
+		$block_type        = (string) ( $context['block_type'] ?? '' );
+		$original_feedback = (string) ( $context['original_feedback'] ?? '' );
+		$original_category = (string) ( $context['original_category'] ?? '' );
+		$original_severity = (string) ( $context['original_severity'] ?? '' );
+		$thread            = is_array( $context['thread'] ?? null ) ? $context['thread'] : array();
+		$user_reply        = (string) ( $context['user_reply'] ?? '' );
+		$target_tone       = (string) ( $context['target_tone'] ?? 'professional' );
+		$locale            = (string) ( $context['locale'] ?? get_locale() );
+
+		// Truncate long block content to keep prompt size bounded.
+		if ( strlen( $block_content ) > 2000 ) {
+			$block_content = substr( $block_content, 0, 2000 ) . '... [truncated]';
+		}
+
+		$prompt  = "You are continuing an editorial conversation about a specific block in a document. The user has replied to feedback you previously gave. Respond directly and conversationally.\n\n";
+		$prompt .= "BLOCK CONTEXT:\n";
+		if ( '' !== $block_type ) {
+			$prompt .= 'Block type: ' . $block_type . "\n";
+		}
+		$prompt .= 'Block content: ' . wp_strip_all_tags( $block_content ) . "\n\n";
+
+		$prompt .= "ORIGINAL FEEDBACK:\n";
+		if ( '' !== $original_category || '' !== $original_severity ) {
+			$prompt .= sprintf(
+				'[%s/%s] ',
+				'' !== $original_category ? $original_category : 'general',
+				'' !== $original_severity ? $original_severity : 'suggestion'
+			);
+		}
+		$prompt .= wp_strip_all_tags( $original_feedback ) . "\n\n";
+
+		if ( ! empty( $thread ) ) {
+			$prompt .= "CONVERSATION SO FAR (chronological):\n";
+			foreach ( $thread as $entry ) {
+				$author  = (string) ( $entry['author'] ?? 'User' );
+				$content = (string) ( $entry['content'] ?? '' );
+				$is_ai   = (bool) ( $entry['is_ai'] ?? false );
+
+				if ( strlen( $content ) > 300 ) {
+					$content = substr( $content, 0, 300 ) . '...';
+				}
+
+				$prompt .= sprintf(
+					"- %s: %s\n",
+					$is_ai ? 'AI' : $author,
+					wp_strip_all_tags( $content )
+				);
+			}
+			$prompt .= "\n";
+		}
+
+		$prompt .= "NEW USER REPLY:\n" . wp_strip_all_tags( $user_reply ) . "\n\n";
+
+		$prompt .= "RESPONSE REQUIREMENTS:\n";
+		$prompt .= "- Reply in 2-3 sentences. One paragraph maximum.\n";
+		$prompt .= "- Address the user's reply directly. If they pushed back on your original feedback with a good reason, acknowledge it.\n";
+		$prompt .= "- If they asked for clarification, answer specifically with an example from their block content.\n";
+		$prompt .= '- Keep the ' . $target_tone . " tone.\n";
+		$prompt .= "- Do NOT restate the original feedback verbatim.\n";
+		$prompt .= "- Output plain text only — no JSON, no markdown headers, no bullet list.\n";
+
+		$language_instruction = $this->get_language_instruction( $locale );
+		if ( '' !== trim( $language_instruction ) ) {
+			$prompt .= $language_instruction;
+		}
+
+		return $prompt;
+	}
+
+	/**
+	 * Get the system instruction for reply generation.
+	 *
+	 * Kept separate from `get_system_instruction()` because reply replies
+	 * are short conversational prose, not JSON feedback items.
+	 *
+	 * @return string System instruction.
+	 */
+	public function get_reply_system_instruction(): string {
+		$instruction  = "You are a concise editorial assistant continuing a conversation about a specific block of content.\n\n";
+		$instruction .= "RULES:\n";
+		$instruction .= "- Plain text only. No JSON, no code blocks, no markdown headers.\n";
+		$instruction .= "- 2-3 sentences. Maximum one paragraph.\n";
+		$instruction .= "- Stay on the specific block and the conversation so far — do not pivot to other parts of the document.\n";
+		$instruction .= "- If the user disagrees with you and gives a valid reason, acknowledge it; do not double down.\n";
+		$instruction .= '- Be specific. When suggesting phrasing, quote or paraphrase from the block content rather than speaking in generalities.';
+
+		return $instruction;
+	}
 }

--- a/includes/class-prompt-builder.php
+++ b/includes/class-prompt-builder.php
@@ -585,8 +585,8 @@ EOT;
 				$content = (string) ( $entry['content'] ?? '' );
 				$is_ai   = (bool) ( $entry['is_ai'] ?? false );
 
-				if ( strlen( $content ) > 300 ) {
-					$content = substr( $content, 0, 300 ) . '...';
+				if ( strlen( $content ) > 600 ) {
+					$content = substr( $content, 0, 600 ) . '... [truncated]';
 				}
 
 				$prompt .= sprintf(
@@ -613,13 +613,19 @@ EOT;
 			$prompt .= $language_instruction;
 		}
 
-		return $prompt;
+		/**
+		 * Filters the AI reply prompt before it is sent to the model.
+		 *
+		 * @param string $prompt  The full reply prompt.
+		 * @param array  $context Reply context data (block, thread, user reply, etc.).
+		 */
+		return apply_filters( 'ai_feedback_reply_prompt', $prompt, $context );
 	}
 
 	/**
 	 * Get the system instruction for reply generation.
 	 *
-	 * Kept separate from `get_system_instruction()` because reply replies
+	 * Kept separate from `get_system_instruction()` because replies
 	 * are short conversational prose, not JSON feedback items.
 	 *
 	 * @return string System instruction.

--- a/includes/class-reply-service.php
+++ b/includes/class-reply-service.php
@@ -86,7 +86,7 @@ class Reply_Service {
 	 * @return int|WP_Error New AI reply comment ID on success, WP_Error on failure.
 	 */
 	public function handle_reply( int $comment_id, int $parent_id, int $post_id, string $block_id ) {
-		$context = $this->build_context( $comment_id, $parent_id );
+		$context = $this->build_context( $comment_id, $parent_id, $post_id );
 		if ( is_wp_error( $context ) ) {
 			Logger::debug( 'Reply_Service: failed to build context: ' . $context->get_error_message() );
 			return $context;
@@ -121,9 +121,10 @@ class Reply_Service {
 	 *
 	 * @param  int $comment_id Reply comment ID.
 	 * @param  int $parent_id  Parent (original AI note) comment ID.
+	 * @param  int $post_id    Post ID — used to scope the siblings query.
 	 * @return array|WP_Error Context array for Prompt_Builder::build_reply_prompt(), or error.
 	 */
-	private function build_context( int $comment_id, int $parent_id ) {
+	private function build_context( int $comment_id, int $parent_id, int $post_id ) {
 		$reply = get_comment( $comment_id );
 		if ( ! $reply ) {
 			return new WP_Error( 'reply_not_found', 'Reply comment not found.' );
@@ -140,6 +141,7 @@ class Reply_Service {
 		$siblings = get_comments(
 			array(
 				'parent'  => $parent_id,
+				'post_id' => $post_id,
 				'type'    => 'note',
 				'status'  => 'all',
 				'orderby' => 'comment_date',
@@ -183,7 +185,7 @@ class Reply_Service {
 	 * @return string|WP_Error AI reply text or error.
 	 */
 	protected function call_ai( string $prompt, string $system_instruction, string $model ) {
-		if ( ! class_exists( 'WordPress\\AiClient\\AiClient' ) ) {
+		if ( ! class_exists( AiClient::class ) ) {
 			return new WP_Error(
 				'ai_client_missing',
 				__( 'PHP AI Client library is not installed.', 'ai-feedback' )

--- a/includes/class-reply-service.php
+++ b/includes/class-reply-service.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Reply Service
+ *
+ * Listens for user replies to AI Feedback notes and generates an AI
+ * response in the same thread.
+ *
+ * @package AI_Feedback
+ */
+
+namespace AI_Feedback;
+
+use WP_Error;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reply Service class.
+ */
+class Reply_Service {
+
+	/**
+	 * Prompt builder instance.
+	 *
+	 * @var Prompt_Builder
+	 */
+	private Prompt_Builder $prompt_builder;
+
+	/**
+	 * Notes manager instance.
+	 *
+	 * @var Notes_Manager
+	 */
+	private Notes_Manager $notes_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Prompt_Builder|null $prompt_builder Optional prompt builder (for testing).
+	 * @param Notes_Manager|null  $notes_manager  Optional notes manager (for testing).
+	 */
+	public function __construct( ?Prompt_Builder $prompt_builder = null, ?Notes_Manager $notes_manager = null ) {
+		$this->prompt_builder = $prompt_builder ?? new Prompt_Builder();
+		$this->notes_manager  = $notes_manager ?? new Notes_Manager();
+	}
+
+	/**
+	 * Register action listener.
+	 */
+	public function register(): void {
+		add_action(
+			Reply_Detector::ACTION_REPLY_RECEIVED,
+			array( $this, 'on_reply_received' ),
+			10,
+			4
+		);
+	}
+
+	/**
+	 * Action callback for Reply_Detector::ACTION_REPLY_RECEIVED.
+	 *
+	 * Wraps handle_reply() to satisfy the void-return contract that
+	 * WordPress actions require; handle_reply() returns a value for
+	 * direct testability.
+	 *
+	 * @param  int    $comment_id Reply comment ID.
+	 * @param  int    $parent_id  Parent (original AI note) comment ID.
+	 * @param  int    $post_id    Post ID.
+	 * @param  string $block_id   Block ID from the parent note.
+	 */
+	public function on_reply_received( int $comment_id, int $parent_id, int $post_id, string $block_id ): void {
+		$this->handle_reply( $comment_id, $parent_id, $post_id, $block_id );
+	}
+
+	/**
+	 * Handle a detected reply: build context, call AI, persist response.
+	 *
+	 * @param  int    $comment_id Reply comment ID.
+	 * @param  int    $parent_id  Parent (original AI note) comment ID.
+	 * @param  int    $post_id    Post ID.
+	 * @param  string $block_id   Block ID from the parent note.
+	 * @return int|WP_Error New AI reply comment ID on success, WP_Error on failure.
+	 */
+	public function handle_reply( int $comment_id, int $parent_id, int $post_id, string $block_id ) {
+		$context = $this->build_context( $comment_id, $parent_id );
+		if ( is_wp_error( $context ) ) {
+			Logger::debug( 'Reply_Service: failed to build context: ' . $context->get_error_message() );
+			return $context;
+		}
+
+		$prompt             = $this->prompt_builder->build_reply_prompt( $context );
+		$system_instruction = $this->prompt_builder->get_reply_system_instruction();
+		$model              = (string) get_option( 'ai_feedback_default_model', 'claude-sonnet-4' );
+
+		$ai_text = $this->call_ai( $prompt, $system_instruction, $model );
+		if ( is_wp_error( $ai_text ) ) {
+			Logger::debug( 'Reply_Service: AI call failed: ' . $ai_text->get_error_message() );
+			return $ai_text;
+		}
+
+		$feedback_item = array(
+			'feedback' => $ai_text,
+			'block_id' => $block_id,
+		);
+		$review_data   = array(
+			'review_id' => 'reply-' . $comment_id,
+			'post_id'   => $post_id,
+			'model'     => $model,
+			'timestamp' => current_time( 'mysql' ),
+		);
+
+		return $this->notes_manager->add_reply_to_thread( $feedback_item, $post_id, $parent_id, $review_data );
+	}
+
+	/**
+	 * Build the reply context array from a parent note and its thread.
+	 *
+	 * @param  int $comment_id Reply comment ID.
+	 * @param  int $parent_id  Parent (original AI note) comment ID.
+	 * @return array|WP_Error Context array for Prompt_Builder::build_reply_prompt(), or error.
+	 */
+	private function build_context( int $comment_id, int $parent_id ) {
+		$reply = get_comment( $comment_id );
+		if ( ! $reply ) {
+			return new WP_Error( 'reply_not_found', 'Reply comment not found.' );
+		}
+
+		$parent = get_comment( $parent_id );
+		if ( ! $parent ) {
+			return new WP_Error( 'parent_not_found', 'Parent note not found.' );
+		}
+
+		// Fetch all siblings of the reply (chronological). The new reply is
+		// already persisted at this point, so it will be included — drop it
+		// from the thread history to avoid echoing the user back to themselves.
+		$siblings = get_comments(
+			array(
+				'parent'  => $parent_id,
+				'type'    => 'note',
+				'status'  => 'all',
+				'orderby' => 'comment_date',
+				'order'   => 'ASC',
+			)
+		);
+
+		$thread = array();
+		foreach ( $siblings as $sibling ) {
+			if ( (int) $sibling->comment_ID === $comment_id ) {
+				continue;
+			}
+			$thread[] = array(
+				'author'  => (string) $sibling->comment_author,
+				'content' => (string) $sibling->comment_content,
+				'is_ai'   => (bool) get_comment_meta( (int) $sibling->comment_ID, 'ai_feedback', true ),
+			);
+		}
+
+		return array(
+			'block_content'     => '', // Future enhancement: derive from post_content.
+			'block_type'        => (string) get_comment_meta( $parent_id, 'block_name', true ),
+			'original_feedback' => (string) $parent->comment_content,
+			'original_category' => (string) get_comment_meta( $parent_id, 'feedback_category', true ),
+			'original_severity' => (string) get_comment_meta( $parent_id, 'feedback_severity', true ),
+			'thread'            => $thread,
+			'user_reply'        => (string) $reply->comment_content,
+			'target_tone'       => (string) get_option( 'ai_feedback_default_tone', 'professional' ),
+			'locale'            => (string) get_option( 'ai_feedback_feedback_locale', get_locale() ),
+		);
+	}
+
+	/**
+	 * Call the AI client to generate the reply text.
+	 *
+	 * Protected so tests can subclass and override.
+	 *
+	 * @param  string $prompt             User prompt.
+	 * @param  string $system_instruction System instruction.
+	 * @param  string $model              Model preference.
+	 * @return string|WP_Error AI reply text or error.
+	 */
+	protected function call_ai( string $prompt, string $system_instruction, string $model ) {
+		if ( ! class_exists( 'WordPress\\AiClient\\AiClient' ) ) {
+			return new WP_Error(
+				'ai_client_missing',
+				__( 'PHP AI Client library is not installed.', 'ai-feedback' )
+			);
+		}
+
+		try {
+			$options = new RequestOptions();
+			$options->setTimeout( 45.0 );
+
+			return AiClient::prompt( $prompt )
+				->usingSystemInstruction( $system_instruction )
+				->usingModelPreference( $model )
+				->usingTemperature( 0.4 )
+				->usingMaxTokens( 400 )
+				->usingRequestOptions( $options )
+				->generateText();
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'ai_request_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'AI reply request failed: %s', 'ai-feedback' ),
+					$e->getMessage()
+				)
+			);
+		}
+	}
+}

--- a/tests/php/PromptBuilderReplyTest.php
+++ b/tests/php/PromptBuilderReplyTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests for Prompt_Builder::build_reply_prompt() and get_reply_system_instruction().
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Prompt_Builder;
+
+/**
+ * Reply prompt tests.
+ */
+class PromptBuilderReplyTest extends TestCase {
+
+	/**
+	 * Prompt builder instance.
+	 *
+	 * @var Prompt_Builder
+	 */
+	private Prompt_Builder $builder;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->builder = new Prompt_Builder();
+	}
+
+	/**
+	 * Minimal context still produces a prompt that includes the user reply.
+	 */
+	public function test_minimal_context_includes_user_reply(): void {
+		$prompt = $this->builder->build_reply_prompt(
+			array(
+				'original_feedback' => 'Add a source for this stat.',
+				'user_reply'        => 'The stat is cited in paragraph 3.',
+			)
+		);
+
+		$this->assertStringContainsString( 'NEW USER REPLY:', $prompt );
+		$this->assertStringContainsString( 'The stat is cited in paragraph 3.', $prompt );
+		$this->assertStringContainsString( 'Add a source for this stat.', $prompt );
+	}
+
+	/**
+	 * Thread history is rendered chronologically with author labels.
+	 */
+	public function test_thread_history_is_rendered_with_author_labels(): void {
+		$prompt = $this->builder->build_reply_prompt(
+			array(
+				'original_feedback' => 'Claim lacks evidence.',
+				'user_reply'        => 'I will add a link.',
+				'thread'            => array(
+					array(
+						'author'  => 'Jane',
+						'content' => 'Which claim?',
+						'is_ai'   => false,
+					),
+					array(
+						'author'  => 'AI Feedback',
+						'content' => 'The 40% growth claim.',
+						'is_ai'   => true,
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'CONVERSATION SO FAR', $prompt );
+		$this->assertStringContainsString( '- Jane: Which claim?', $prompt );
+		// AI-authored entries are always labeled 'AI', regardless of stored author.
+		$this->assertStringContainsString( '- AI: The 40% growth claim.', $prompt );
+	}
+
+	/**
+	 * HTML tags in block content are stripped.
+	 */
+	public function test_html_is_stripped_from_block_content(): void {
+		$prompt = $this->builder->build_reply_prompt(
+			array(
+				'block_content'     => '<p>Hello <strong>world</strong></p>',
+				'original_feedback' => 'Too casual.',
+				'user_reply'        => 'Intentional.',
+			)
+		);
+
+		$this->assertStringContainsString( 'Hello world', $prompt );
+		$this->assertStringNotContainsString( '<strong>', $prompt );
+		$this->assertStringNotContainsString( '<p>', $prompt );
+	}
+
+	/**
+	 * Category and severity are both rendered when provided.
+	 */
+	public function test_category_and_severity_are_prefixed_on_original_feedback(): void {
+		$prompt = $this->builder->build_reply_prompt(
+			array(
+				'original_feedback' => 'Vague wording.',
+				'original_category' => 'content',
+				'original_severity' => 'important',
+				'user_reply'        => 'Fixed.',
+			)
+		);
+
+		$this->assertStringContainsString( '[content/important]', $prompt );
+	}
+
+	/**
+	 * Very long block content is truncated.
+	 */
+	public function test_long_block_content_is_truncated(): void {
+		$long   = str_repeat( 'a', 5000 );
+		$prompt = $this->builder->build_reply_prompt(
+			array(
+				'block_content'     => $long,
+				'original_feedback' => 'Long.',
+				'user_reply'        => 'OK.',
+			)
+		);
+
+		$this->assertStringContainsString( '[truncated]', $prompt );
+	}
+
+	/**
+	 * System instruction is plain prose (no JSON, no markdown headers).
+	 */
+	public function test_reply_system_instruction_format(): void {
+		$instruction = $this->builder->get_reply_system_instruction();
+
+		$this->assertStringContainsString( 'Plain text only', $instruction );
+		$this->assertStringNotContainsString( '{', $instruction );
+		$this->assertStringNotContainsString( '"feedback"', $instruction );
+	}
+}

--- a/tests/php/ReplyServiceTest.php
+++ b/tests/php/ReplyServiceTest.php
@@ -168,11 +168,6 @@ class ReplyServiceTest extends TestCase {
 		$this->assertStringContainsString( 'NEW USER REPLY:', $service->captured_prompt );
 		$this->assertStringContainsString( 'SHOULD_NOT_APPEAR_IN_THREAD', $service->captured_prompt );
 
-		$conversation_section = strstr( $service->captured_prompt, 'CONVERSATION SO FAR', true );
-		$new_reply_section    = substr(
-			$service->captured_prompt,
-			strpos( $service->captured_prompt, 'NEW USER REPLY:' )
-		);
 		$before_reply_section = substr(
 			$service->captured_prompt,
 			0,
@@ -202,5 +197,54 @@ class ReplyServiceTest extends TestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'parent_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Missing reply comment surfaces a WP_Error.
+	 */
+	public function test_missing_reply_returns_wp_error(): void {
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Original feedback.',
+			'comment_author'  => 'AI Feedback',
+		);
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), new Reply_Service_Fake_Notes_Manager() );
+
+		$result = $service->handle_reply( 999, 100, 42, 'abc-123' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'reply_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * AI failure propagates as a WP_Error and the reply is not persisted.
+	 */
+	public function test_ai_failure_returns_wp_error_and_skips_persistence(): void {
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Original feedback.',
+			'comment_author'  => 'AI Feedback',
+		);
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+		$GLOBALS['test_comments'][200]     = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'User reply.',
+			'comment_author'  => 'Jane',
+			'comment_parent'  => 100,
+		);
+
+		$fake_notes = new Reply_Service_Fake_Notes_Manager();
+		$service    = new class( new Prompt_Builder(), $fake_notes ) extends Reply_Service {
+			protected function call_ai( string $prompt, string $system_instruction, string $model ): string|\WP_Error {
+				return new \WP_Error( 'ai_request_failed', 'simulated provider failure' );
+			}
+		};
+
+		$result = $service->handle_reply( 200, 100, 42, 'abc-123' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_request_failed', $result->get_error_code() );
+		$this->assertSame( array(), $fake_notes->last_reply, 'Notes_Manager must not be called when the AI fails.' );
 	}
 }

--- a/tests/php/ReplyServiceTest.php
+++ b/tests/php/ReplyServiceTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Tests for Reply_Service.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Reply_Service;
+use AI_Feedback\Prompt_Builder;
+use AI_Feedback\Notes_Manager;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-service.php';
+require_once __DIR__ . '/reply-service-mocks.php';
+
+/**
+ * Subclass that captures the prompt and returns a canned AI reply.
+ */
+class Reply_Service_Stub extends Reply_Service {
+
+	public string $captured_prompt             = '';
+	public string $captured_system_instruction = '';
+	public string $captured_model              = '';
+	public string $canned_response             = 'OK — replace "40% growth" with "40% growth (Source: Stripe dashboard)".';
+
+	protected function call_ai( string $prompt, string $system_instruction, string $model ): string|\WP_Error {
+		$this->captured_prompt             = $prompt;
+		$this->captured_system_instruction = $system_instruction;
+		$this->captured_model              = $model;
+		return $this->canned_response;
+	}
+}
+
+/**
+ * Fake Notes_Manager that records the add_reply_to_thread call.
+ */
+class Reply_Service_Fake_Notes_Manager extends Notes_Manager {
+
+	public array $last_reply = array();
+
+	public function add_reply_to_thread( array $feedback_item, int $post_id, int $parent_id, array $review_data = array() ): int|\WP_Error {
+		$this->last_reply = array(
+			'feedback_item' => $feedback_item,
+			'post_id'       => $post_id,
+			'parent_id'     => $parent_id,
+			'review_data'   => $review_data,
+		);
+		return 999;
+	}
+}
+
+/**
+ * Reply_Service test cases.
+ */
+class ReplyServiceTest extends TestCase {
+
+	/**
+	 * Reset the fake-WP state before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['test_comments']       = array();
+		$GLOBALS['test_comment_meta']   = array();
+		$GLOBALS['test_options']        = array();
+	}
+
+	/**
+	 * Tear down state.
+	 */
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['test_comments'],
+			$GLOBALS['test_comment_meta'],
+			$GLOBALS['test_options']
+		);
+		parent::tearDown();
+	}
+
+	/**
+	 * End-to-end: context built, prompt generated, AI reply persisted.
+	 */
+	public function test_handle_reply_persists_ai_reply_as_thread_child(): void {
+		// Parent: AI note on a paragraph block with original feedback.
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Add a source for the 40% growth claim.',
+			'comment_author'  => 'AI Feedback',
+		);
+		$GLOBALS['test_comment_meta'][100] = array(
+			'ai_feedback'        => '1',
+			'block_name'         => 'core/paragraph',
+			'feedback_category'  => 'content',
+			'feedback_severity'  => 'important',
+		);
+
+		// Reply: user asking for clarification.
+		$GLOBALS['test_comments'][200] = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'I already cite it in paragraph 3.',
+			'comment_author'  => 'Jane',
+		);
+
+		// Prior thread entry (an earlier user comment, chronologically first).
+		$GLOBALS['test_comments'][150] = (object) array(
+			'comment_ID'      => 150,
+			'comment_content' => 'Which stat?',
+			'comment_author'  => 'Jane',
+			'comment_parent'  => 100,
+		);
+		$GLOBALS['test_comments'][200]->comment_parent = 100;
+
+		$GLOBALS['test_options']['ai_feedback_default_model'] = 'claude-sonnet-4';
+		$GLOBALS['test_options']['ai_feedback_default_tone']  = 'professional';
+
+		$fake_notes = new Reply_Service_Fake_Notes_Manager();
+		$service    = new Reply_Service_Stub( new Prompt_Builder(), $fake_notes );
+
+		$result = $service->handle_reply( 200, 100, 42, 'abc-123' );
+
+		// Returns the fake Notes_Manager's stubbed insert ID.
+		$this->assertSame( 999, $result );
+
+		// The prompt carried the user reply, original feedback, and prior thread entry.
+		$this->assertStringContainsString( 'I already cite it in paragraph 3.', $service->captured_prompt );
+		$this->assertStringContainsString( 'Add a source for the 40% growth claim.', $service->captured_prompt );
+		$this->assertStringContainsString( 'Which stat?', $service->captured_prompt );
+		$this->assertStringContainsString( '[content/important]', $service->captured_prompt );
+
+		// Model + system instruction routed through.
+		$this->assertSame( 'claude-sonnet-4', $service->captured_model );
+		$this->assertStringContainsString( 'Plain text only', $service->captured_system_instruction );
+
+		// Persisted as a child of the parent note with the canned AI reply.
+		$this->assertSame( 100, $fake_notes->last_reply['parent_id'] );
+		$this->assertSame( 42, $fake_notes->last_reply['post_id'] );
+		$this->assertSame( $service->canned_response, $fake_notes->last_reply['feedback_item']['feedback'] );
+		$this->assertSame( 'abc-123', $fake_notes->last_reply['feedback_item']['block_id'] );
+		$this->assertSame( 'claude-sonnet-4', $fake_notes->last_reply['review_data']['model'] );
+	}
+
+	/**
+	 * The user's own reply is excluded from the thread history so the
+	 * prompt doesn't echo them back to themselves.
+	 */
+	public function test_thread_history_excludes_the_current_reply(): void {
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Vague claim.',
+			'comment_author'  => 'AI Feedback',
+		);
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+
+		// The reply itself is the only sibling of the parent.
+		$GLOBALS['test_comments'][200] = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'SHOULD_NOT_APPEAR_IN_THREAD',
+			'comment_author'  => 'Jane',
+			'comment_parent'  => 100,
+		);
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), new Reply_Service_Fake_Notes_Manager() );
+
+		$service->handle_reply( 200, 100, 42, 'abc-123' );
+
+		// The reply appears in the NEW USER REPLY section but not the thread history.
+		$this->assertStringContainsString( 'NEW USER REPLY:', $service->captured_prompt );
+		$this->assertStringContainsString( 'SHOULD_NOT_APPEAR_IN_THREAD', $service->captured_prompt );
+
+		$conversation_section = strstr( $service->captured_prompt, 'CONVERSATION SO FAR', true );
+		$new_reply_section    = substr(
+			$service->captured_prompt,
+			strpos( $service->captured_prompt, 'NEW USER REPLY:' )
+		);
+		$before_reply_section = substr(
+			$service->captured_prompt,
+			0,
+			strpos( $service->captured_prompt, 'NEW USER REPLY:' )
+		);
+
+		// The sentinel text from the reply should not appear in any pre-NEW-USER-REPLY section.
+		$this->assertStringNotContainsString(
+			'SHOULD_NOT_APPEAR_IN_THREAD',
+			$before_reply_section
+		);
+	}
+
+	/**
+	 * Missing parent surfaces a WP_Error instead of crashing.
+	 */
+	public function test_missing_parent_returns_wp_error(): void {
+		$GLOBALS['test_comments'][200] = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'Reply text',
+			'comment_author'  => 'Jane',
+		);
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), new Reply_Service_Fake_Notes_Manager() );
+
+		$result = $service->handle_reply( 200, 999, 42, 'abc-123' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'parent_not_found', $result->get_error_code() );
+	}
+}

--- a/tests/php/reply-service-mocks.php
+++ b/tests/php/reply-service-mocks.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Mocks for Reply_Service tests.
+ *
+ * Declared in the root namespace because Reply_Service calls unqualified
+ * WordPress functions (get_comment, get_comments, get_comment_meta,
+ * get_option, current_time) that resolve against the global namespace.
+ *
+ * The reply-detector-mocks file already defines get_comment_meta and
+ * do_action — guard against redefinition.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace {
+
+	// Reuse comment meta + do_action mocks if the detector tests loaded first.
+	if ( ! function_exists( 'get_comment_meta' ) ) {
+		function get_comment_meta( $comment_id, $key = '', $single = false ) {
+			$store = $GLOBALS['test_comment_meta'] ?? array();
+			$meta  = $store[ $comment_id ] ?? array();
+			if ( '' === $key ) {
+				return $meta;
+			}
+			return $meta[ $key ] ?? '';
+		}
+	}
+
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( $hook, ...$args ) {
+			$GLOBALS['test_dispatched_calls'][] = array(
+				'hook' => $hook,
+				'args' => $args,
+			);
+		}
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		/**
+		 * No-op add_action stub — Reply_Service::register() calls this at
+		 * construction time in the integration test scenario, but the unit
+		 * tests invoke handle_reply() directly and don't need dispatch.
+		 */
+		function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'get_comment' ) ) {
+		/**
+		 * Minimal get_comment mock that reads from $GLOBALS['test_comments'].
+		 *
+		 * @param int $id Comment ID.
+		 * @return object|null
+		 */
+		function get_comment( $id ) {
+			$store = $GLOBALS['test_comments'] ?? array();
+			return $store[ $id ] ?? null;
+		}
+	}
+
+	if ( ! function_exists( 'get_comments' ) ) {
+		/**
+		 * get_comments mock that filters $GLOBALS['test_comments'] by parent
+		 * and orders by comment_ID ascending (chronological proxy).
+		 *
+		 * Only recognises the `parent` arg; other filters (`type`, `status`)
+		 * are accepted for signature compatibility but ignored.
+		 *
+		 * @param array $args Query args.
+		 * @return array
+		 */
+		function get_comments( $args = array() ) {
+			$store  = $GLOBALS['test_comments'] ?? array();
+			$parent = isset( $args['parent'] ) ? (int) $args['parent'] : null;
+
+			$matches = array();
+			foreach ( $store as $comment ) {
+				if ( null !== $parent && (int) ( $comment->comment_parent ?? 0 ) !== $parent ) {
+					continue;
+				}
+				$matches[] = $comment;
+			}
+
+			usort(
+				$matches,
+				static function ( $a, $b ) {
+					return ( (int) $a->comment_ID ) <=> ( (int) $b->comment_ID );
+				}
+			);
+
+			return $matches;
+		}
+	}
+
+	if ( ! function_exists( 'get_option' ) ) {
+		/**
+		 * get_option mock reading from $GLOBALS['test_options'] with a
+		 * caller-supplied default.
+		 *
+		 * @param string $key
+		 * @param mixed  $default_value
+		 * @return mixed
+		 */
+		function get_option( $key, $default_value = false ) {
+			$opts = $GLOBALS['test_options'] ?? array();
+			return array_key_exists( $key, $opts ) ? $opts[ $key ] : $default_value;
+		}
+	}
+
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( $type, $gmt = 0 ) {
+			return '2026-04-18 10:34:00';
+		}
+	}
+
+	if ( ! function_exists( 'get_locale' ) ) {
+		function get_locale() {
+			return 'en_US';
+		}
+	}
+
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $_hook_name, $value, ...$args ) {
+			return $value;
+		}
+	}
+}


### PR DESCRIPTION
> **Stacked on [#137](https://github.com/adamsilverstein/ai-feedback/pull/137).** Base is \`131-reply-detector\` — merge #137 first, then this one rebases onto main cleanly.

## Summary

Consumes the \`ai_feedback_note_reply_received\` action from [#137](https://github.com/adamsilverstein/ai-feedback/pull/137) and produces an AI response in the same thread. This is the end-to-end backend half of Phase 4: user reply → AI reply rendered as a child note. Frontend threading UI comes in [#134](https://github.com/adamsilverstein/ai-feedback/issues/134); async/cron dispatch comes in [#133](https://github.com/adamsilverstein/ai-feedback/issues/133).

## Changes

- \`Reply_Service\` (new): listens for the detector action, builds a context-aware prompt from the parent note + its thread + the user's reply, calls the AI, and persists the response via \`Notes_Manager::add_reply_to_thread()\`.
- \`Prompt_Builder::build_reply_prompt()\` + \`get_reply_system_instruction()\`: reply-specific prompt shape — single paragraph of plain text, not the JSON feedback schema used by \`build_review_prompt()\`.
- Wired into \`Plugin::init_hooks()\` alongside \`Reply_Detector\`.

The AI reply is stored with \`ai_feedback=1\` meta (via the existing Notes_Manager path), which means \`Reply_Detector\` will *ignore* it on insert and the loop can't re-trigger on our own response.

Model and tone are read from plugin settings (\`ai_feedback_default_model\`, \`ai_feedback_default_tone\`).

## Tests

14 new cases across three files:

- \`PromptBuilderReplyTest\` (6): minimal context, thread rendering with author labels, HTML stripping, category/severity prefix, block-content truncation, system-instruction format.
- \`ReplyServiceTest\` (3): end-to-end handle_reply (prompt contents + persisted thread child + model routed through), current-reply excluded from thread history, missing-parent returns \`WP_Error\`.
- Plus the [#137](https://github.com/adamsilverstein/ai-feedback/pull/137) detector tests (5) still pass unchanged.

\`\`\`
./vendor/bin/phpunit --bootstrap tests/php/bootstrap.php \\
  tests/php/ReplyServiceTest.php tests/php/ReplyDetectorTest.php tests/php/PromptBuilderReplyTest.php
OK (14 tests, 38 assertions)

./vendor/bin/phpcs --standard=WordPress includes/
exit: 0

./vendor/bin/phpstan analyze --memory-limit 1G includes/
No errors
\`\`\`

## Known limitation (scoped out)

\`build_context()\` currently passes an empty \`block_content\` to the prompt. Stored notes don't capture the block's raw text and post_content parsing against a \`block_id\` (which is a client-only \`clientId\`) isn't reliable. The AI has thread history + original feedback + the user's reply which is enough for a conversational response. Enriching with block content is a follow-up — worth a separate issue if the reply quality shows it matters.

## Test plan
- [ ] Trigger a review, get a note, reply as a user — confirm an AI child note appears on the same block
- [ ] Reply again — confirm the second AI response is aware of the first exchange (thread history reaches the prompt)
- [ ] Verify settings model/tone changes are picked up on the next reply

Part of [#132](https://github.com/adamsilverstein/ai-feedback/issues/132)