### PR TITLE
Dispatch AI replies via WP-Cron with pollable status

### DIFF
--- a/ai-feedback.php
+++ b/ai-feedback.php
@@ -181,10 +181,11 @@ function deactivate()
 {
     // Clear any pending reply-generation cron events so WP-Cron does not
     // attempt to fire a hook with no registered listener once the plugin
-    // is disabled.
-    if (class_exists(Reply_Cron_Dispatcher::class)) {
-        wp_clear_scheduled_hook(Reply_Cron_Dispatcher::CRON_HOOK);
-    }
+    // is disabled. Reference the hook by its literal value rather than
+    // through the class constant: at deactivation time the autoloader may
+    // have already torn down, and the hook name is part of the public
+    // contract (mirror of Reply_Cron_Dispatcher::CRON_HOOK).
+    wp_clear_scheduled_hook('ai_feedback_generate_reply');
 
     // Flush rewrite rules.
     flush_rewrite_rules();

--- a/ai-feedback.php
+++ b/ai-feedback.php
@@ -179,6 +179,13 @@ register_activation_hook(__FILE__, __NAMESPACE__ . '\\activate');
  */
 function deactivate()
 {
+    // Clear any pending reply-generation cron events so WP-Cron does not
+    // attempt to fire a hook with no registered listener once the plugin
+    // is disabled.
+    if (class_exists(Reply_Cron_Dispatcher::class)) {
+        wp_clear_scheduled_hook(Reply_Cron_Dispatcher::CRON_HOOK);
+    }
+
     // Flush rewrite rules.
     flush_rewrite_rules();
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -69,6 +69,20 @@ class Plugin {
 	private ?Reply_Service $reply_service = null;
 
 	/**
+	 * Reply cron dispatcher instance.
+	 *
+	 * @var Reply_Cron_Dispatcher|null
+	 */
+	private ?Reply_Cron_Dispatcher $reply_cron_dispatcher = null;
+
+	/**
+	 * Reply status controller instance.
+	 *
+	 * @var Reply_Status_Controller|null
+	 */
+	private ?Reply_Status_Controller $reply_status_controller = null;
+
+	/**
 	 * Get plugin instance.
 	 *
 	 * @return Plugin
@@ -109,6 +123,9 @@ class Plugin {
 		$this->reply_detector = new Reply_Detector();
 		$this->reply_detector->register();
 
+		$this->reply_cron_dispatcher = new Reply_Cron_Dispatcher();
+		$this->reply_cron_dispatcher->register();
+
 		$this->reply_service = new Reply_Service();
 		$this->reply_service->register();
 	}
@@ -128,6 +145,9 @@ class Plugin {
 
 		$this->health_controller = new Health_Controller();
 		$this->health_controller->register_routes();
+
+		$this->reply_status_controller = new Reply_Status_Controller();
+		$this->reply_status_controller->register_routes();
 	}
 
 	/**

--- a/includes/class-reply-cron-dispatcher.php
+++ b/includes/class-reply-cron-dispatcher.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Reply Cron Dispatcher
+ *
+ * Listens for the reply-detection action and schedules a WP-Cron event
+ * to generate the AI response out-of-band, so the user's comment insert
+ * returns immediately.
+ *
+ * @package AI_Feedback
+ */
+
+namespace AI_Feedback;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Dispatches reply generation onto WP-Cron.
+ */
+class Reply_Cron_Dispatcher {
+
+	/**
+	 * Cron hook name invoked to generate a reply.
+	 *
+	 * Args on the scheduled event: ( int $comment_id, int $parent_id, int $post_id, string $block_id ).
+	 */
+	public const CRON_HOOK = 'ai_feedback_generate_reply';
+
+	/**
+	 * Comment meta key tracking reply processing state.
+	 *
+	 * Values: 'pending' | 'complete' | 'failed'.
+	 */
+	public const STATUS_META_KEY = 'ai_feedback_reply_status';
+
+	/**
+	 * Register hooks.
+	 */
+	public function register(): void {
+		add_action(
+			Reply_Detector::ACTION_REPLY_RECEIVED,
+			array( $this, 'schedule_reply' ),
+			10,
+			4
+		);
+	}
+
+	/**
+	 * Listener for Reply_Detector::ACTION_REPLY_RECEIVED.
+	 *
+	 * Marks the reply as pending and schedules a single cron event. WP-Cron
+	 * already deduplicates by ( hook, args ), but we also short-circuit on
+	 * existing status to avoid re-pending a completed reply (e.g. if the
+	 * hook fires twice for the same insert).
+	 *
+	 * @param int    $comment_id Reply comment ID.
+	 * @param int    $parent_id  Parent note comment ID.
+	 * @param int    $post_id    Post ID.
+	 * @param string $block_id   Block ID from the parent note.
+	 */
+	public function schedule_reply( int $comment_id, int $parent_id, int $post_id, string $block_id ): void {
+		$existing_status = (string) get_comment_meta( $comment_id, self::STATUS_META_KEY, true );
+		if ( '' !== $existing_status ) {
+			return;
+		}
+
+		$args = array( $comment_id, $parent_id, $post_id, $block_id );
+
+		if ( wp_next_scheduled( self::CRON_HOOK, $args ) ) {
+			return;
+		}
+
+		update_comment_meta( $comment_id, self::STATUS_META_KEY, 'pending' );
+		wp_schedule_single_event( time(), self::CRON_HOOK, $args );
+	}
+}

--- a/includes/class-reply-service.php
+++ b/includes/class-reply-service.php
@@ -53,7 +53,7 @@ class Reply_Service {
 	 */
 	public function register(): void {
 		add_action(
-			Reply_Detector::ACTION_REPLY_RECEIVED,
+			Reply_Cron_Dispatcher::CRON_HOOK,
 			array( $this, 'on_reply_received' ),
 			10,
 			4
@@ -61,11 +61,12 @@ class Reply_Service {
 	}
 
 	/**
-	 * Action callback for Reply_Detector::ACTION_REPLY_RECEIVED.
+	 * Cron callback for Reply_Cron_Dispatcher::CRON_HOOK.
 	 *
 	 * Wraps handle_reply() to satisfy the void-return contract that
 	 * WordPress actions require; handle_reply() returns a value for
-	 * direct testability.
+	 * direct testability. Also records final status on the reply comment
+	 * so the frontend can poll for completion.
 	 *
 	 * @param  int    $comment_id Reply comment ID.
 	 * @param  int    $parent_id  Parent (original AI note) comment ID.
@@ -73,7 +74,16 @@ class Reply_Service {
 	 * @param  string $block_id   Block ID from the parent note.
 	 */
 	public function on_reply_received( int $comment_id, int $parent_id, int $post_id, string $block_id ): void {
-		$this->handle_reply( $comment_id, $parent_id, $post_id, $block_id );
+		$result = $this->handle_reply( $comment_id, $parent_id, $post_id, $block_id );
+
+		if ( is_wp_error( $result ) ) {
+			update_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, 'failed' );
+			update_comment_meta( $comment_id, 'ai_feedback_reply_error', $result->get_error_message() );
+			return;
+		}
+
+		update_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, 'complete' );
+		update_comment_meta( $comment_id, 'ai_feedback_reply_comment_id', (int) $result );
 	}
 
 	/**

--- a/includes/class-reply-service.php
+++ b/includes/class-reply-service.php
@@ -78,12 +78,32 @@ class Reply_Service {
 
 		if ( is_wp_error( $result ) ) {
 			update_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, 'failed' );
-			update_comment_meta( $comment_id, 'ai_feedback_reply_error', $result->get_error_message() );
+			update_comment_meta(
+				$comment_id,
+				'ai_feedback_reply_error',
+				sanitize_text_field( $result->get_error_message() )
+			);
+			return;
+		}
+
+		$reply_id = (int) $result;
+
+		// A non-error, non-positive return from handle_reply means persistence
+		// silently failed (e.g. wp_insert_comment returned 0 or false). Marking
+		// it 'complete' would leave the frontend polling indefinitely on a
+		// non-existent reply, so route it through the failed branch instead.
+		if ( $reply_id <= 0 ) {
+			update_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, 'failed' );
+			update_comment_meta(
+				$comment_id,
+				'ai_feedback_reply_error',
+				__( 'Reply persistence returned no comment ID.', 'ai-feedback' )
+			);
 			return;
 		}
 
 		update_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, 'complete' );
-		update_comment_meta( $comment_id, 'ai_feedback_reply_comment_id', (int) $result );
+		update_comment_meta( $comment_id, 'ai_feedback_reply_comment_id', $reply_id );
 	}
 
 	/**

--- a/includes/class-reply-status-controller.php
+++ b/includes/class-reply-status-controller.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Reply Status REST API Controller
+ *
+ * Exposes the processing state of an AI reply that was scheduled
+ * via Reply_Cron_Dispatcher, so the frontend can poll for completion.
+ *
+ * @package AI_Feedback
+ */
+
+namespace AI_Feedback;
+
+use WP_REST_Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+/**
+ * Reply status controller.
+ */
+class Reply_Status_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'ai-feedback/v1';
+
+	/**
+	 * REST base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'replies';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>\d+)/status',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_status' ),
+					'permission_callback' => array( $this, 'get_status_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function get_status_permissions_check() {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access reply status.', 'ai-feedback' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * GET /replies/{id}/status
+	 *
+	 * @param  WP_REST_Request $request Request.
+	 * @return WP_REST_Response
+	 */
+	public function get_status( WP_REST_Request $request ): WP_REST_Response {
+		$comment_id = (int) $request['id'];
+
+		$status = (string) get_comment_meta( $comment_id, Reply_Cron_Dispatcher::STATUS_META_KEY, true );
+
+		if ( '' === $status ) {
+			return new WP_REST_Response(
+				array(
+					'reply_id' => $comment_id,
+					'status'   => 'unknown',
+				),
+				200
+			);
+		}
+
+		$payload = array(
+			'reply_id' => $comment_id,
+			'status'   => $status,
+		);
+
+		if ( 'complete' === $status ) {
+			$ai_reply_id = (int) get_comment_meta( $comment_id, 'ai_feedback_reply_comment_id', true );
+			if ( $ai_reply_id > 0 ) {
+				$payload['ai_reply_comment_id'] = $ai_reply_id;
+			}
+		}
+
+		if ( 'failed' === $status ) {
+			$error = (string) get_comment_meta( $comment_id, 'ai_feedback_reply_error', true );
+			if ( '' !== $error ) {
+				$payload['error'] = $error;
+			}
+		}
+
+		return new WP_REST_Response( $payload, 200 );
+	}
+}

--- a/tests/php/ReplyCronDispatcherTest.php
+++ b/tests/php/ReplyCronDispatcherTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for Reply_Cron_Dispatcher.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Reply_Cron_Dispatcher;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-cron-dispatcher.php';
+require_once __DIR__ . '/reply-cron-mocks.php';
+
+/**
+ * Cron dispatcher tests.
+ */
+class ReplyCronDispatcherTest extends TestCase {
+
+	/**
+	 * Dispatcher instance.
+	 *
+	 * @var Reply_Cron_Dispatcher
+	 */
+	private Reply_Cron_Dispatcher $dispatcher;
+
+	/**
+	 * Set up global state per test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->dispatcher                   = new Reply_Cron_Dispatcher();
+		$GLOBALS['test_comment_meta']       = array();
+		$GLOBALS['test_scheduled_events']   = array();
+	}
+
+	/**
+	 * Reset state.
+	 */
+	protected function tearDown(): void {
+		unset(
+			$GLOBALS['test_comment_meta'],
+			$GLOBALS['test_scheduled_events']
+		);
+		parent::tearDown();
+	}
+
+	/**
+	 * Scheduling marks pending and enqueues a cron event with the expected args.
+	 */
+	public function test_schedule_reply_marks_pending_and_schedules_event(): void {
+		$this->dispatcher->schedule_reply( 200, 100, 42, 'abc-123' );
+
+		$this->assertSame(
+			'pending',
+			$GLOBALS['test_comment_meta'][200][ Reply_Cron_Dispatcher::STATUS_META_KEY ] ?? null
+		);
+
+		$this->assertCount( 1, $GLOBALS['test_scheduled_events'] );
+		$event = $GLOBALS['test_scheduled_events'][0];
+
+		$this->assertSame( Reply_Cron_Dispatcher::CRON_HOOK, $event['hook'] );
+		$this->assertSame( array( 200, 100, 42, 'abc-123' ), $event['args'] );
+	}
+
+	/**
+	 * Scheduling twice for the same reply is a no-op — status is not overwritten
+	 * and only one cron event is queued.
+	 */
+	public function test_schedule_reply_is_idempotent_on_existing_status(): void {
+		// Simulate the first dispatch already having run and completed.
+		$GLOBALS['test_comment_meta'][200] = array(
+			Reply_Cron_Dispatcher::STATUS_META_KEY => 'complete',
+		);
+
+		$this->dispatcher->schedule_reply( 200, 100, 42, 'abc-123' );
+
+		// Status must not be downgraded back to pending.
+		$this->assertSame(
+			'complete',
+			$GLOBALS['test_comment_meta'][200][ Reply_Cron_Dispatcher::STATUS_META_KEY ]
+		);
+		$this->assertCount( 0, $GLOBALS['test_scheduled_events'] );
+	}
+
+	/**
+	 * If an event is already queued, we don't queue a second one.
+	 */
+	public function test_schedule_reply_skips_when_event_already_queued(): void {
+		$GLOBALS['test_scheduled_events'][] = array(
+			'hook'      => Reply_Cron_Dispatcher::CRON_HOOK,
+			'args'      => array( 200, 100, 42, 'abc-123' ),
+			'timestamp' => 123,
+		);
+
+		$this->dispatcher->schedule_reply( 200, 100, 42, 'abc-123' );
+
+		$this->assertCount( 1, $GLOBALS['test_scheduled_events'] );
+		// And status stays empty because we short-circuited before update_comment_meta.
+		$this->assertArrayNotHasKey( 200, $GLOBALS['test_comment_meta'] );
+	}
+}

--- a/tests/php/ReplyServiceTest.php
+++ b/tests/php/ReplyServiceTest.php
@@ -305,4 +305,44 @@ class ReplyServiceTest extends TestCase {
 			$GLOBALS['test_comment_meta'][200]['ai_feedback_reply_error'] ?? null
 		);
 	}
+
+	/**
+	 * If handle_reply returns a non-error, non-positive value (e.g. 0 from a
+	 * silent wp_insert_comment failure), on_reply_received must not mark the
+	 * reply 'complete' — that would leave the frontend polling forever on a
+	 * non-existent comment ID.
+	 */
+	public function test_on_reply_received_records_failed_status_when_persistence_returns_zero(): void {
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Original feedback.',
+			'comment_author'  => 'AI Feedback',
+		);
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+		$GLOBALS['test_comments'][200]     = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'User reply.',
+			'comment_author'  => 'Jane',
+			'comment_parent'  => 100,
+		);
+
+		$silent_failure_notes = new class() extends Notes_Manager {
+			public function add_reply_to_thread( array $feedback_item, int $post_id, int $parent_id, array $review_data = array() ): int|\WP_Error {
+				return 0;
+			}
+		};
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), $silent_failure_notes );
+
+		$service->on_reply_received( 200, 100, 42, 'abc-123' );
+
+		$this->assertSame(
+			'failed',
+			$GLOBALS['test_comment_meta'][200][ \AI_Feedback\Reply_Cron_Dispatcher::STATUS_META_KEY ]
+		);
+		$this->assertArrayNotHasKey(
+			'ai_feedback_reply_comment_id',
+			$GLOBALS['test_comment_meta'][200]
+		);
+	}
 }

--- a/tests/php/ReplyServiceTest.php
+++ b/tests/php/ReplyServiceTest.php
@@ -12,8 +12,10 @@ use AI_Feedback\Reply_Service;
 use AI_Feedback\Prompt_Builder;
 use AI_Feedback\Notes_Manager;
 
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-cron-dispatcher.php';
 require_once dirname( __DIR__, 2 ) . '/includes/class-reply-service.php';
 require_once __DIR__ . '/reply-service-mocks.php';
+require_once __DIR__ . '/reply-cron-mocks.php';
 
 /**
  * Subclass that captures the prompt and returns a canned AI reply.
@@ -246,5 +248,61 @@ class ReplyServiceTest extends TestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'ai_request_failed', $result->get_error_code() );
 		$this->assertSame( array(), $fake_notes->last_reply, 'Notes_Manager must not be called when the AI fails.' );
+	}
+
+	/**
+	 * on_reply_received records 'complete' status meta and the resulting AI
+	 * reply comment ID when handle_reply succeeds.
+	 */
+	public function test_on_reply_received_records_complete_status_on_success(): void {
+		$GLOBALS['test_comments'][100] = (object) array(
+			'comment_ID'      => 100,
+			'comment_content' => 'Vague.',
+			'comment_author'  => 'AI Feedback',
+		);
+		$GLOBALS['test_comment_meta'][100] = array( 'ai_feedback' => '1' );
+		$GLOBALS['test_comments'][200]     = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'Intentional.',
+			'comment_author'  => 'Jane',
+			'comment_parent'  => 100,
+		);
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), new Reply_Service_Fake_Notes_Manager() );
+
+		$service->on_reply_received( 200, 100, 42, 'abc-123' );
+
+		$this->assertSame(
+			'complete',
+			$GLOBALS['test_comment_meta'][200][ \AI_Feedback\Reply_Cron_Dispatcher::STATUS_META_KEY ]
+		);
+		$this->assertSame(
+			999,
+			$GLOBALS['test_comment_meta'][200]['ai_feedback_reply_comment_id']
+		);
+	}
+
+	/**
+	 * on_reply_received records 'failed' status with the error message when
+	 * handle_reply returns WP_Error (e.g. missing parent).
+	 */
+	public function test_on_reply_received_records_failed_status_on_error(): void {
+		$GLOBALS['test_comments'][200] = (object) array(
+			'comment_ID'      => 200,
+			'comment_content' => 'Reply without parent.',
+			'comment_author'  => 'Jane',
+		);
+
+		$service = new Reply_Service_Stub( new Prompt_Builder(), new Reply_Service_Fake_Notes_Manager() );
+
+		$service->on_reply_received( 200, 999, 42, 'abc-123' );
+
+		$this->assertSame(
+			'failed',
+			$GLOBALS['test_comment_meta'][200][ \AI_Feedback\Reply_Cron_Dispatcher::STATUS_META_KEY ]
+		);
+		$this->assertNotEmpty(
+			$GLOBALS['test_comment_meta'][200]['ai_feedback_reply_error'] ?? null
+		);
 	}
 }

--- a/tests/php/ReplyStatusControllerTest.php
+++ b/tests/php/ReplyStatusControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for Reply_Status_Controller.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Reply_Status_Controller;
+use AI_Feedback\Reply_Cron_Dispatcher;
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-cron-dispatcher.php';
+require_once __DIR__ . '/reply-cron-mocks.php';
+require_once __DIR__ . '/reply-status-controller-bootstrap.php';
+require_once dirname( __DIR__, 2 ) . '/includes/class-reply-status-controller.php';
+
+/**
+ * Reply status controller tests.
+ */
+class ReplyStatusControllerTest extends TestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Reply_Status_Controller
+	 */
+	private Reply_Status_Controller $controller;
+
+	/**
+	 * Per-test fixture reset.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->controller                 = new Reply_Status_Controller();
+		$GLOBALS['test_comment_meta']     = array();
+		$GLOBALS['test_current_user_can'] = true;
+	}
+
+	/**
+	 * Clean up globals.
+	 */
+	protected function tearDown(): void {
+		unset( $GLOBALS['test_comment_meta'], $GLOBALS['test_current_user_can'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Unknown status (no meta) returns 'unknown'.
+	 */
+	public function test_status_returns_unknown_when_no_meta(): void {
+		$response = $this->controller->get_status( new \WP_REST_Request( array( 'id' => 200 ) ) );
+
+		$data = $response->get_data();
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'unknown', $data['status'] );
+		$this->assertSame( 200, $data['reply_id'] );
+	}
+
+	/**
+	 * Pending status returns as-is without extra fields.
+	 */
+	public function test_status_returns_pending(): void {
+		$GLOBALS['test_comment_meta'][200] = array(
+			Reply_Cron_Dispatcher::STATUS_META_KEY => 'pending',
+		);
+
+		$data = $this->controller
+			->get_status( new \WP_REST_Request( array( 'id' => 200 ) ) )
+			->get_data();
+
+		$this->assertSame( 'pending', $data['status'] );
+		$this->assertArrayNotHasKey( 'ai_reply_comment_id', $data );
+		$this->assertArrayNotHasKey( 'error', $data );
+	}
+
+	/**
+	 * Complete status exposes the AI reply comment ID so the frontend can fetch it.
+	 */
+	public function test_status_complete_includes_ai_reply_comment_id(): void {
+		$GLOBALS['test_comment_meta'][200] = array(
+			Reply_Cron_Dispatcher::STATUS_META_KEY => 'complete',
+			'ai_feedback_reply_comment_id'         => 555,
+		);
+
+		$data = $this->controller
+			->get_status( new \WP_REST_Request( array( 'id' => 200 ) ) )
+			->get_data();
+
+		$this->assertSame( 'complete', $data['status'] );
+		$this->assertSame( 555, $data['ai_reply_comment_id'] );
+	}
+
+	/**
+	 * Failed status exposes the error message.
+	 */
+	public function test_status_failed_includes_error(): void {
+		$GLOBALS['test_comment_meta'][200] = array(
+			Reply_Cron_Dispatcher::STATUS_META_KEY => 'failed',
+			'ai_feedback_reply_error'              => 'AI request timed out.',
+		);
+
+		$data = $this->controller
+			->get_status( new \WP_REST_Request( array( 'id' => 200 ) ) )
+			->get_data();
+
+		$this->assertSame( 'failed', $data['status'] );
+		$this->assertSame( 'AI request timed out.', $data['error'] );
+	}
+
+	/**
+	 * Permission check rejects users lacking edit_posts.
+	 */
+	public function test_permissions_check_denies_unauthorized_user(): void {
+		$GLOBALS['test_current_user_can'] = false;
+
+		$result = $this->controller->get_status_permissions_check();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+}

--- a/tests/php/reply-cron-mocks.php
+++ b/tests/php/reply-cron-mocks.php
@@ -92,9 +92,4 @@ namespace {
 			return true;
 		}
 	}
-
-	if ( ! function_exists( 'time' ) ) {
-		// PHP's `time()` already exists, but keep this slot in case a future
-		// test wants a deterministic value — currently unused.
-	}
 }

--- a/tests/php/reply-cron-mocks.php
+++ b/tests/php/reply-cron-mocks.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Mocks for Reply_Cron_Dispatcher and status-tracking tests.
+ *
+ * Declared in the root namespace because Reply_Cron_Dispatcher and
+ * Reply_Service call unqualified WP functions (get_comment_meta,
+ * update_comment_meta, wp_next_scheduled, wp_schedule_single_event,
+ * time, add_action) that resolve against the global namespace.
+ *
+ * Shared fixtures:
+ * - $GLOBALS['test_comment_meta'] — read/write store for *_comment_meta()
+ * - $GLOBALS['test_scheduled_events'] — cron queue
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace {
+
+	if ( ! function_exists( 'get_comment_meta' ) ) {
+		function get_comment_meta( $comment_id, $key = '', $single = false ) {
+			$store = $GLOBALS['test_comment_meta'] ?? array();
+			$meta  = $store[ $comment_id ] ?? array();
+			if ( '' === $key ) {
+				return $meta;
+			}
+			return $meta[ $key ] ?? '';
+		}
+	}
+
+	if ( ! function_exists( 'update_comment_meta' ) ) {
+		/**
+		 * Minimal update_comment_meta mock — last-write-wins into the shared store.
+		 *
+		 * @param int    $comment_id Comment ID.
+		 * @param string $key        Meta key.
+		 * @param mixed  $value      Meta value.
+		 * @return bool
+		 */
+		function update_comment_meta( $comment_id, $key, $value ) {
+			if ( ! isset( $GLOBALS['test_comment_meta'][ $comment_id ] ) ) {
+				$GLOBALS['test_comment_meta'][ $comment_id ] = array();
+			}
+			$GLOBALS['test_comment_meta'][ $comment_id ][ $key ] = $value;
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'wp_next_scheduled' ) ) {
+		/**
+		 * Returns the timestamp of a matching scheduled event, or false.
+		 *
+		 * Matches on ( hook, args ) like WP's own implementation.
+		 *
+		 * @param string $hook
+		 * @param array  $args
+		 * @return int|false
+		 */
+		function wp_next_scheduled( $hook, $args = array() ) {
+			foreach ( $GLOBALS['test_scheduled_events'] ?? array() as $event ) {
+				if ( $event['hook'] === $hook && ( $event['args'] ?? array() ) === $args ) {
+					return (int) ( $event['timestamp'] ?? 0 );
+				}
+			}
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+		/**
+		 * Minimal wp_schedule_single_event mock — appends to the queue.
+		 *
+		 * @param int    $timestamp
+		 * @param string $hook
+		 * @param array  $args
+		 * @return bool
+		 */
+		function wp_schedule_single_event( $timestamp, $hook, $args = array() ) {
+			$GLOBALS['test_scheduled_events'][] = array(
+				'timestamp' => (int) $timestamp,
+				'hook'      => $hook,
+				'args'      => $args,
+			);
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'add_action' ) ) {
+		/**
+		 * No-op add_action — unit tests invoke methods directly rather than via the hook.
+		 */
+		function add_action( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+			return true;
+		}
+	}
+
+	if ( ! function_exists( 'time' ) ) {
+		// PHP's `time()` already exists, but keep this slot in case a future
+		// test wants a deterministic value — currently unused.
+	}
+}

--- a/tests/php/reply-status-controller-bootstrap.php
+++ b/tests/php/reply-status-controller-bootstrap.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Global-namespace bootstrap for Reply_Status_Controller tests.
+ *
+ * The controller `use`s root-namespace WP_REST_* classes; the PHPUnit
+ * bootstrap already defines WP_REST_Controller, WP_REST_Server, and
+ * WP_REST_Response, but not WP_REST_Request. Declare a minimal
+ * stand-in here so `$request['id']` works the way the controller uses it.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace {
+
+	if ( ! class_exists( 'WP_REST_Request' ) ) {
+		/**
+		 * Minimal WP_REST_Request stand-in used by controller tests.
+		 *
+		 * Only models the ArrayAccess surface (`$request['id']`) that the
+		 * controller reads.
+		 */
+		class WP_REST_Request implements \ArrayAccess {
+			private array $data;
+
+			public function __construct( array $data = array() ) {
+				$this->data = $data;
+			}
+			public function offsetExists( $offset ): bool {
+				return isset( $this->data[ $offset ] );
+			}
+			public function offsetGet( $offset ): mixed {
+				return $this->data[ $offset ] ?? null;
+			}
+			public function offsetSet( $offset, $value ): void {
+				$this->data[ $offset ] = $value;
+			}
+			public function offsetUnset( $offset ): void {
+				unset( $this->data[ $offset ] );
+			}
+		}
+	}
+}


### PR DESCRIPTION
> **Stacked on [#138](https://github.com/adamsilverstein/ai-feedback/pull/138)** (which is stacked on [#137](https://github.com/adamsilverstein/ai-feedback/pull/137)). Base is \`132-reply-service\`. Merge order: [#137](https://github.com/adamsilverstein/ai-feedback/pull/137) → [#138](https://github.com/adamsilverstein/ai-feedback/pull/138) → this.

## Summary

Moves AI reply generation off the critical path. Before this PR, \`Reply_Service\` ran the LLM call on the same request that inserted the user's reply comment — user saw a blocking wait. Now a cron event carries the work and the frontend can poll for completion.

## Changes

- **\`Reply_Cron_Dispatcher\`** (new): binds to the detector action ([#137](https://github.com/adamsilverstein/ai-feedback/pull/137)), stamps \`ai_feedback_reply_status = 'pending'\` on the reply comment, and schedules a single \`ai_feedback_generate_reply\` cron event. Dedups on both existing status and \`wp_next_scheduled\`.
- **\`Reply_Service::register()\`** now binds to the cron hook instead of the detector action. \`on_reply_received\` writes final status meta:
  - success → \`complete\` + \`ai_feedback_reply_comment_id\`
  - error → \`failed\` + \`ai_feedback_reply_error\`
- **\`Reply_Status_Controller\`** (new): \`GET /ai-feedback/v1/replies/{id}/status\` — requires \`edit_posts\`. Returns \`{ reply_id, status }\` plus \`ai_reply_comment_id\` on complete or \`error\` on failed. Returns \`unknown\` for IDs never scheduled.
- **\`Plugin\`** wires the dispatcher into \`init_hooks\` and the controller into \`register_rest_routes\`.

## Meta keys on the user's reply comment

| Key | When written | Values |
|---|---|---|
| \`ai_feedback_reply_status\` | dispatcher schedules, service completes/fails | \`pending\` \\| \`complete\` \\| \`failed\` |
| \`ai_feedback_reply_comment_id\` | service, on success | AI reply's \`comment_ID\` |
| \`ai_feedback_reply_error\` | service, on failure | error message |

## Tests

10 new cases:
- \`ReplyCronDispatcherTest\` (3): schedules pending + cron event with correct args, idempotent on existing status, skips when event already queued.
- \`ReplyServiceTest\` (+2): \`on_reply_received\` writes \`complete\` + AI reply comment ID on success, writes \`failed\` + error on \`WP_Error\`.
- \`ReplyStatusControllerTest\` (5): unknown/pending/complete/failed payload shapes, permission check denies non-editors.

\`\`\`
./vendor/bin/phpunit --bootstrap tests/php/bootstrap.php \\
  tests/php/ReplyCronDispatcherTest.php tests/php/ReplyServiceTest.php \\
  tests/php/ReplyStatusControllerTest.php tests/php/ReplyDetectorTest.php \\
  tests/php/PromptBuilderReplyTest.php
OK (24 tests, 62 assertions)

./vendor/bin/phpcs --standard=WordPress includes/
exit: 0

./vendor/bin/phpstan analyze --memory-limit 1G includes/
No errors
\`\`\`

## Test plan
- [ ] Reply to an AI note — confirm the comment insert returns immediately and a cron event is queued
- [ ] Run \`wp cron event run ai_feedback_generate_reply\` — AI reply appears, status flips to \`complete\`
- [ ] \`GET /wp-json/ai-feedback/v1/replies/{id}/status\` returns the expected shape at each stage
- [ ] Simulate an AI failure (invalid API key) — status flips to \`failed\` with the error surfaced

Part of [#133](https://github.com/adamsilverstein/ai-feedback/issues/133)