### PR TITLE
Fix comment_type reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,12 @@ ai-feedback/
 
 ### Notes (WordPress 6.9+)
 
-Notes are block-level comments stored in `wp_comments` with `comment_type = 'block_comment'`. The plugin creates notes when AI generates feedback:
+Notes are block-level comments stored in `wp_comments` with `comment_type = 'note'`. The plugin creates notes when AI generates feedback:
 
 ```php
 // Creating a note (simplified)
 wp_insert_comment( [
-    'comment_type'    => 'block_comment',
+    'comment_type'    => 'note',
     'comment_post_ID' => $post_id,
     'comment_content' => $feedback,
     'comment_meta'    => [ 'block_id' => $client_id, 'ai_feedback' => true ],


### PR DESCRIPTION
## Summary
Notes_Manager::create_note() inserts notes as comment_type 'note' (per Reply_Detector and the actual storage shape), but CLAUDE.md still documented 'block_comment'. The mismatch surfaced in repeated review feedback on the Phase 4 work — reviewers reading CLAUDE.md kept flagging the detector's 'note' check as a potential bug.

## Test plan
- [x] Diff is doc-only; no code paths affected
- [ ] Confirm rendered Markdown in the GitHub preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify how plugin notes are stored and managed within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->