### PR TITLE
Migrate to WordPress 7.0 core AI Client and Connectors API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AI Feedback Plugin
 
-AI-powered editorial feedback for WordPress Gutenberg using the Notes feature (WP 6.9+).
+AI-powered editorial feedback for WordPress Gutenberg using the WordPress 7.0 core AI Client, Connectors API, and Notes feature.
 
 ## Workflow
 
@@ -69,7 +69,7 @@ ai-feedback/
 
 ## Key Concepts
 
-### Notes (WordPress 6.9+)
+### Notes (WordPress 7.0+)
 
 Notes are block-level comments stored in `wp_comments` with `comment_type = 'block_comment'`. The plugin creates notes when AI generates feedback:
 
@@ -83,17 +83,19 @@ wp_insert_comment( [
 ] );
 ```
 
-### PHP AI Client
+### Core AI Client (WordPress 7.0)
 
-Uses `wordpress/php-ai-client` for provider-agnostic AI communication:
+Uses the core `wp_ai_client_prompt()` builder for provider-agnostic AI communication. Credentials come from the Connectors API (Settings → Connectors), so the plugin never handles API keys directly:
 
 ```php
-use WordPress\AiClient\AiClient;
+$response = wp_ai_client_prompt( $prompt )
+    ->using_system_instruction( $system_prompt )
+    ->using_temperature( 0.3 )
+    ->generate_text();
 
-$response = AiClient::prompt( $prompt )
-    ->usingSystemInstruction( $system_prompt )
-    ->usingTemperature( 0.3 )
-    ->generateText();
+if ( is_wp_error( $response ) ) {
+    return $response;
+}
 ```
 
 ### Data Flow
@@ -124,7 +126,7 @@ Edit `class-prompt-builder.php`. Consider:
 
 ## Dependencies
 
-**Runtime:** WordPress 6.9+, PHP 8.1+, [AI Experiments plugin](https://wordpress.org/plugins/ai/)
+**Runtime:** WordPress 7.0+, PHP 8.1+ (the core AI Client and Connectors API are bundled in WordPress 7.0)
 
 **Development:** Node 18+, Composer 2+, Docker (for wp-env)
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # AI Feedback Plugin
 
-AI-powered editorial feedback for WordPress Gutenberg editor using WordPress 6.9's Notes feature.
+AI-powered editorial feedback for WordPress Gutenberg, built on WordPress 7.0's core AI Client, Connectors API, and Notes feature.
 
 ## Overview
 
-The AI Feedback plugin integrates AI-powered content review directly into the WordPress block editor. It leverages the native Notes API (WordPress 6.9+) to provide contextual, block-level feedback on your content.
+The AI Feedback plugin integrates AI-powered content review directly into the WordPress block editor. It uses the WordPress 7.0 core [AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/) for provider-agnostic AI access, the [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) for credentials, and the native Notes API for contextual, block-level feedback.
 
 ## Features
 
 - 🤖 **AI-Powered Reviews**: Get intelligent feedback on content quality, tone, flow, and design
 - 📝 **Native Notes Integration**: Feedback appears as WordPress block comments
-- ⚙️ **Configurable Settings**: Choose AI models, focus areas, and target tone
-- 🔄 **Multiple AI Providers**: Support for Claude, GPT-4, Gemini, and more
+- 🔌 **Core Connectors API**: Reuses the credentials configured in Settings → Connectors
+- 🔄 **Multiple AI Providers**: Works with Anthropic, OpenAI, Google, and any other provider registered with the core AI Client
 - 💬 **Conversational Feedback**: Reply to AI suggestions and get clarifications (Phase 4)
 - 🎯 **Focus Areas**: Content Quality, Tone & Voice, Flow & Structure, Design & Formatting
 
 ## Requirements
 
-- **WordPress**: 6.9 or higher
-- **PHP**: 8.0 or higher
-- **Plugins**: [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/)
+- **WordPress**: 7.0 or higher
+- **PHP**: 8.1 or higher
+- **AI Provider**: At least one provider configured under Settings → Connectors
 - **Node.js**: 18.0 or higher (for development)
 - **npm**: 9.0 or higher (for development)
 
@@ -27,16 +27,13 @@ The AI Feedback plugin integrates AI-powered content review directly into the Wo
 
 ### Prerequisites
 
-The AI Feedback plugin requires the [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/) to be installed and activated. The AI Experiments plugin provides:
-- Centralized AI settings screen for configuring API keys
-- Support for multiple AI providers (Anthropic, OpenAI, Google Gemini, etc.)
-- Common interface for AI configuration across WordPress plugins
+WordPress 7.0 ships the AI Client and Connectors API in core, so AI Feedback no longer needs the standalone AI Experiments plugin or a separate Composer-installed AI SDK.
 
-**Install the AI Experiments plugin first:**
-1. Go to WordPress Admin → Plugins → Add New
-2. Search for "AI Experiments" or "AI"
-3. Click "Install Now" and then "Activate"
-4. Configure your AI provider API keys in Settings → AI
+Before using AI Feedback, configure an AI provider:
+1. Go to WordPress Admin → **Settings → Connectors**.
+2. Choose a provider (Anthropic, OpenAI, Google, etc.).
+3. Provide an API key directly, or set the corresponding environment variable / PHP constant (e.g. `ANTHROPIC_API_KEY`). Environment variables and PHP constants take precedence over database-stored values.
+4. Save.
 
 ### 1. Clone the Repository
 
@@ -87,29 +84,27 @@ If using wp-env, the plugin is automatically activated. Otherwise:
 
 ### AI Provider Setup
 
-The plugin uses the [WordPress PHP AI Client](https://github.com/WordPress/php-ai-client) which works in conjunction with the [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/) for managing AI provider credentials.
+The plugin calls WordPress 7.0's `wp_ai_client_prompt()` directly, so credentials are managed by the core [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/).
 
-**Option 1: Using the AI Experiments Plugin (Recommended)**
+**Option 1: Settings → Connectors (recommended)**
 
-Configure your AI provider through the WordPress admin interface:
-1. Go to Settings → AI in WordPress admin
-2. Select your preferred AI provider (Anthropic, OpenAI, Google Gemini, etc.)
-3. Enter your API key
-4. Save settings
+1. Go to **Settings → Connectors** in WordPress admin.
+2. Pick a provider (Anthropic, OpenAI, Google, etc.).
+3. Enter the API key.
+4. Save.
 
-**Option 2: Using wp-config.php**
+**Option 2: Environment variables or PHP constants**
 
-Alternatively, you can configure your AI provider directly in `wp-config.php`:
+The Connectors API checks for credentials in this order:
+1. Environment variable (e.g. `ANTHROPIC_API_KEY`)
+2. PHP constant (defined via `define()`)
+3. Database setting saved via the Connectors screen
 
 ```php
-// For Anthropic Claude (default)
+// In wp-config.php — these take precedence over the database value.
 define( 'ANTHROPIC_API_KEY', 'your-api-key-here' );
-
-// For OpenAI
-define( 'OPENAI_API_KEY', 'your-api-key-here' );
-
-// For Google Gemini
-define( 'GOOGLE_AI_API_KEY', 'your-api-key-here' );
+define( 'OPENAI_API_KEY',    'your-api-key-here' );
+define( 'GOOGLE_API_KEY',    'your-api-key-here' );
 ```
 
 ### Default Settings
@@ -337,16 +332,15 @@ GPL v2 or later
 
 ## Credits
 
-- Requires [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/)
-- Built with [WordPress PHP AI Client](https://github.com/WordPress/php-ai-client)
-- Uses WordPress 6.9+ Notes API
-- Powered by AI providers: Anthropic, OpenAI, Google
+- Built on the WordPress 7.0 core [AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/) and [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/)
+- Uses the WordPress Notes API for block-level comments
+- Powered by AI providers: Anthropic, OpenAI, Google (any provider registered with the core AI Client)
 
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/yourusername/ai-feedback/issues)
 - **Documentation**: [docs/](docs/)
-- **WordPress**: Requires 6.9+
+- **WordPress**: Requires 7.0+
 
 ## Changelog
 

--- a/ai-feedback.php
+++ b/ai-feedback.php
@@ -18,167 +18,155 @@
 namespace AI_Feedback;
 
 // Exit if accessed directly.
-if (! defined('ABSPATH') ) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 // Define plugin constants.
-define('AI_FEEDBACK_VERSION', '0.2.0');
-define('AI_FEEDBACK_PLUGIN_FILE', __FILE__);
-define('AI_FEEDBACK_PLUGIN_DIR', plugin_dir_path(__FILE__));
-define('AI_FEEDBACK_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('AI_FEEDBACK_PLUGIN_BASENAME', plugin_basename(__FILE__));
+define( 'AI_FEEDBACK_VERSION', '0.2.0' );
+define( 'AI_FEEDBACK_PLUGIN_FILE', __FILE__ );
+define( 'AI_FEEDBACK_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'AI_FEEDBACK_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'AI_FEEDBACK_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 // Require Composer autoloader.
-if (file_exists(AI_FEEDBACK_PLUGIN_DIR . 'vendor/autoload.php') ) {
-    include_once AI_FEEDBACK_PLUGIN_DIR . 'vendor/autoload.php';
+if ( file_exists( AI_FEEDBACK_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
+	include_once AI_FEEDBACK_PLUGIN_DIR . 'vendor/autoload.php';
 }
 
 // Simple autoloader for plugin classes.
 spl_autoload_register(
-    function ( $class ) {
-        // Check if this is our namespace.
-        if (strpos($class, 'AI_Feedback\\') !== 0 ) {
-            return;
-        }
+	function ( $class ) {
+		// Check if this is our namespace.
+		if ( strpos( $class, 'AI_Feedback\\' ) !== 0 ) {
+			return;
+		}
 
-        // Remove namespace prefix.
-        $class = str_replace('AI_Feedback\\', '', $class);
+		// Remove namespace prefix.
+		$class = str_replace( 'AI_Feedback\\', '', $class );
 
-        // Convert class name to file name.
-        $file = 'class-' . strtolower(str_replace('_', '-', $class)) . '.php';
+		// Convert class name to file name.
+		$file = 'class-' . strtolower( str_replace( '_', '-', $class ) ) . '.php';
 
-        // Build full file path.
-        $path = AI_FEEDBACK_PLUGIN_DIR . 'includes/' . $file;
+		// Build full file path.
+		$path = AI_FEEDBACK_PLUGIN_DIR . 'includes/' . $file;
 
-        // Require the file if it exists.
-        if (file_exists($path) ) {
-            include_once $path;
-        }
-    }
+		// Require the file if it exists.
+		if ( file_exists( $path ) ) {
+			include_once $path;
+		}
+	}
 );
 
 // Enable mock mode for testing without AI API calls.
 // Set this to true in wp-config.php: define( 'AI_FEEDBACK_MOCK_MODE', true );
-if (! defined('AI_FEEDBACK_MOCK_MODE') ) {
-    define('AI_FEEDBACK_MOCK_MODE', false);
+if ( ! defined( 'AI_FEEDBACK_MOCK_MODE' ) ) {
+	define( 'AI_FEEDBACK_MOCK_MODE', false );
 }
 
 /**
  * Initialize the plugin.
  */
-function init()
-{
-    // Check WordPress version.
-    if (version_compare(get_bloginfo('version'), '7.0', '<') ) {
-        add_action('admin_notices', __NAMESPACE__ . '\\display_version_notice');
-        return;
-    }
+function init() {
+	// Check WordPress version.
+	if ( version_compare( get_bloginfo( 'version' ), '7.0', '<' ) ) {
+		add_action( 'admin_notices', __NAMESPACE__ . '\\display_version_notice' );
+		return;
+	}
 
-    // Check PHP version.
-    if (version_compare(PHP_VERSION, '8.1', '<') ) {
-        add_action('admin_notices', __NAMESPACE__ . '\\display_php_version_notice');
-        return;
-    }
+	// Check PHP version.
+	if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
+		add_action( 'admin_notices', __NAMESPACE__ . '\\display_php_version_notice' );
+		return;
+	}
 
-    // Verify the core AI Client is available (introduced in WordPress 7.0).
-    if (! function_exists('wp_ai_client_prompt') ) {
-        add_action('admin_notices', __NAMESPACE__ . '\\display_ai_client_notice');
-        return;
-    }
+	// Verify the core AI Client is available (introduced in WordPress 7.0).
+	if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+		add_action( 'admin_notices', __NAMESPACE__ . '\\display_ai_client_notice' );
+		return;
+	}
 
-    // Initialize the plugin.
-    Plugin::get_instance();
+	// Initialize the plugin.
+	Plugin::get_instance();
 }
-add_action('plugins_loaded', __NAMESPACE__ . '\\init');
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\init' );
 
 /**
  * Display WordPress version notice.
  */
-function display_version_notice()
-{
-    ?>
-    <div class="notice notice-error">
-        <p>
-    <?php
-    printf(
-                /* translators: %s: required WordPress version */
-        esc_html__('AI Feedback requires WordPress %s or higher.', 'ai-feedback'),
-        '7.0'
-    );
-    ?>
-        </p>
-    </div>
-    <?php
+function display_version_notice() {
+	?>
+	<div class="notice notice-error">
+		<p>
+	<?php
+	printf(
+				/* translators: %s: required WordPress version */
+		esc_html__( 'AI Feedback requires WordPress %s or higher.', 'ai-feedback' ),
+		'7.0'
+	);
+	?>
+		</p>
+	</div>
+	<?php
 }
 
 /**
  * Display PHP version notice.
  */
-function display_php_version_notice()
-{
-    ?>
-    <div class="notice notice-error">
-        <p>
-    <?php
-    printf(
-                /* translators: %s: required PHP version */
-        esc_html__('AI Feedback requires PHP %s or higher.', 'ai-feedback'),
-        '8.1'
-    );
-    ?>
-        </p>
-    </div>
-    <?php
+function display_php_version_notice() {
+	?>
+	<div class="notice notice-error">
+		<p>
+	<?php
+	printf(
+				/* translators: %s: required PHP version */
+		esc_html__( 'AI Feedback requires PHP %s or higher.', 'ai-feedback' ),
+		'8.1'
+	);
+	?>
+		</p>
+	</div>
+	<?php
 }
 
 /**
  * Display core AI Client unavailable notice.
  */
-function display_ai_client_notice()
-{
-    ?>
-    <div class="notice notice-error">
-        <p>
-    <?php
-    printf(
-        /* translators: %s: URL of the WordPress updates screen */
-        wp_kses(
-            __( 'AI Feedback requires the WordPress core AI Client (introduced in WordPress 7.0). <a href="%s">Update WordPress</a> to use this plugin.', 'ai-feedback' ),
-            array( 'a' => array( 'href' => array() ) )
-        ),
-        esc_url(admin_url('update-core.php'))
-    );
-    ?>
-        </p>
-    </div>
-    <?php
+function display_ai_client_notice() {
+	$message = sprintf(
+		/* translators: %s: URL of the WordPress updates screen */
+		__( 'AI Feedback requires the WordPress core AI Client (introduced in WordPress 7.0). <a href="%s">Update WordPress</a> to use this plugin.', 'ai-feedback' ),
+		esc_url( admin_url( 'update-core.php' ) )
+	);
+	?>
+	<div class="notice notice-error">
+		<p><?php echo wp_kses_post( $message ); ?></p>
+	</div>
+	<?php
 }
 
 /**
  * Plugin activation hook.
  */
-function activate()
-{
-    // Set default options.
-    add_option('ai_feedback_default_model', 'claude-sonnet-4');
-    add_option('ai_feedback_default_focus_areas', array( 'content', 'tone', 'flow' ));
-    add_option('ai_feedback_default_tone', 'professional');
-    add_option('ai_feedback_version', AI_FEEDBACK_VERSION);
+function activate() {
+	// Set default options.
+	add_option( 'ai_feedback_default_model', 'claude-sonnet-4' );
+	add_option( 'ai_feedback_default_focus_areas', array( 'content', 'tone', 'flow' ) );
+	add_option( 'ai_feedback_default_tone', 'professional' );
+	add_option( 'ai_feedback_version', AI_FEEDBACK_VERSION );
 
-    // Flush rewrite rules.
-    flush_rewrite_rules();
+	// Flush rewrite rules.
+	flush_rewrite_rules();
 }
-register_activation_hook(__FILE__, __NAMESPACE__ . '\\activate');
+register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
 
 /**
  * Plugin deactivation hook.
  */
-function deactivate()
-{
-    // Flush rewrite rules.
-    flush_rewrite_rules();
+function deactivate() {
+	// Flush rewrite rules.
+	flush_rewrite_rules();
 }
-register_deactivation_hook(__FILE__, __NAMESPACE__ . '\\deactivate');
+register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivate' );
 
-require_once plugin_dir_path(__FILE__) . 'includes/class-logger.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-logger.php';

--- a/ai-feedback.php
+++ b/ai-feedback.php
@@ -2,11 +2,10 @@
 /**
  * Plugin Name: AI Feedback
  * Plugin URI: https://github.com/adamsilverstein/ai-feedback
- * Description: AI-powered editorial feedback in the Gutenberg editor using WordPress 6.9's Notes feature.
- * Version: 0.1.0
- * Requires at least: 6.9
- * Requires PHP: 8.0
- * Requires Plugins: ai
+ * Description: AI-powered editorial feedback in the Gutenberg editor using WordPress 7.0's core AI Client and Notes feature.
+ * Version: 0.2.0
+ * Requires at least: 7.0
+ * Requires PHP: 8.1
  * Author: Adam Silverstein
  * Author URI: https://wordpress.org/profiles/adamsilverstein/
  * License: GPL v2 or later
@@ -24,7 +23,7 @@ if (! defined('ABSPATH') ) {
 }
 
 // Define plugin constants.
-define('AI_FEEDBACK_VERSION', '0.1.0');
+define('AI_FEEDBACK_VERSION', '0.2.0');
 define('AI_FEEDBACK_PLUGIN_FILE', __FILE__);
 define('AI_FEEDBACK_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('AI_FEEDBACK_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -71,25 +70,20 @@ if (! defined('AI_FEEDBACK_MOCK_MODE') ) {
 function init()
 {
     // Check WordPress version.
-    if (version_compare(get_bloginfo('version'), '6.9', '<') ) {
+    if (version_compare(get_bloginfo('version'), '7.0', '<') ) {
         add_action('admin_notices', __NAMESPACE__ . '\\display_version_notice');
         return;
     }
 
     // Check PHP version.
-    if (version_compare(PHP_VERSION, '8.0', '<') ) {
+    if (version_compare(PHP_VERSION, '8.1', '<') ) {
         add_action('admin_notices', __NAMESPACE__ . '\\display_php_version_notice');
         return;
     }
 
-    // Check for AI Experiments plugin dependency.
-    // Include plugin.php for is_plugin_active function.
-    if (! function_exists('is_plugin_active') ) {
-        include_once ABSPATH . 'wp-admin/includes/plugin.php';
-    }
-
-    if (! is_plugin_active('ai/ai.php') && ! is_plugin_active('ai-experiments/ai.php') ) {
-        add_action('admin_notices', __NAMESPACE__ . '\\display_ai_plugin_notice');
+    // Verify the core AI Client is available (introduced in WordPress 7.0).
+    if (! function_exists('wp_ai_client_prompt') ) {
+        add_action('admin_notices', __NAMESPACE__ . '\\display_ai_client_notice');
         return;
     }
 
@@ -110,7 +104,7 @@ function display_version_notice()
     printf(
                 /* translators: %s: required WordPress version */
         esc_html__('AI Feedback requires WordPress %s or higher.', 'ai-feedback'),
-        '6.9'
+        '7.0'
     );
     ?>
         </p>
@@ -130,7 +124,7 @@ function display_php_version_notice()
     printf(
                 /* translators: %s: required PHP version */
         esc_html__('AI Feedback requires PHP %s or higher.', 'ai-feedback'),
-        '8.0'
+        '8.1'
     );
     ?>
         </p>
@@ -139,18 +133,17 @@ function display_php_version_notice()
 }
 
 /**
- * Display AI Experiments plugin dependency notice.
+ * Display core AI Client unavailable notice.
  */
-function display_ai_plugin_notice()
+function display_ai_client_notice()
 {
     ?>
     <div class="notice notice-error">
         <p>
     <?php
-    printf(
-                /* translators: %s: link to AI plugin */
-        wp_kses_post(__('AI Feedback requires the <a href="%s" target="_blank">WordPress AI Experiments plugin</a> to be installed and activated.', 'ai-feedback')),
-        'https://wordpress.org/plugins/ai/'
+    esc_html_e(
+        'AI Feedback requires the WordPress core AI Client (introduced in WordPress 7.0). Please update WordPress to use this plugin.',
+        'ai-feedback'
     );
     ?>
         </p>

--- a/ai-feedback.php
+++ b/ai-feedback.php
@@ -141,9 +141,13 @@ function display_ai_client_notice()
     <div class="notice notice-error">
         <p>
     <?php
-    esc_html_e(
-        'AI Feedback requires the WordPress core AI Client (introduced in WordPress 7.0). Please update WordPress to use this plugin.',
-        'ai-feedback'
+    printf(
+        /* translators: %s: URL of the WordPress updates screen */
+        wp_kses(
+            __( 'AI Feedback requires the WordPress core AI Client (introduced in WordPress 7.0). <a href="%s">Update WordPress</a> to use this plugin.', 'ai-feedback' ),
+            array( 'a' => array( 'href' => array() ) )
+        ),
+        esc_url(admin_url('update-core.php'))
     );
     ?>
         </p>

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.1",
-		"wordpress/php-ai-client": "^0.3.0"
+		"php": ">=8.1"
 	},
 	"require-dev": {
 		"mockery/mockery": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,479 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66695ef095d97af7ead094c79c794849",
-    "packages": [
-        {
-            "name": "php-http/discovery",
-            "version": "1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/discovery.git",
-                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
-                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0|^2.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "nyholm/psr7": "<1.0",
-                "zendframework/zend-diactoros": "*"
-            },
-            "provide": {
-                "php-http/async-client-implementation": "*",
-                "php-http/client-implementation": "*",
-                "psr/http-client-implementation": "*",
-                "psr/http-factory-implementation": "*",
-                "psr/http-message-implementation": "*"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0.2|^2.0",
-                "graham-campbell/phpspec-skip-example-extension": "^5.0",
-                "php-http/httplug": "^1.0 || ^2.0",
-                "php-http/message-factory": "^1.0",
-                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
-                "sebastian/comparator": "^3.0.5 || ^4.0.8",
-                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Http\\Discovery\\Composer\\Plugin",
-                "plugin-optional": true
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Discovery\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "src/Composer/Plugin.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "adapter",
-                "client",
-                "discovery",
-                "factory",
-                "http",
-                "message",
-                "psr17",
-                "psr7"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.20.0"
-            },
-            "time": "2024-10-02T11:20:13+00:00"
-        },
-        {
-            "name": "php-http/httplug",
-            "version": "2.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/httplug.git",
-                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/httplug/zipball/5cad731844891a4c282f3f3e1b582c46839d22f4",
-                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "php-http/promise": "^1.1",
-                "psr/http-client": "^1.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "require-dev": {
-                "friends-of-phpspec/phpspec-code-coverage": "^4.1 || ^5.0 || ^6.0",
-                "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Eric GELOEN",
-                    "email": "geloen.eric@gmail.com"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://sagikazarmark.hu"
-                }
-            ],
-            "description": "HTTPlug, the HTTP client abstraction for PHP",
-            "homepage": "http://httplug.io",
-            "keywords": [
-                "client",
-                "http"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/httplug/issues",
-                "source": "https://github.com/php-http/httplug/tree/2.4.1"
-            },
-            "time": "2024-09-23T11:39:58+00:00"
-        },
-        {
-            "name": "php-http/message-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message-factory.git",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Factory interfaces for PSR-7 HTTP Message",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
-            },
-            "abandoned": "psr/http-factory",
-            "time": "2023-04-14T14:16:17+00:00"
-        },
-        {
-            "name": "php-http/promise",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/promise.git",
-                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/promise/zipball/fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
-                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2 || ^6.3",
-                "phpspec/phpspec": "^5.1.2 || ^6.2 || ^7.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Http\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Joel Wurtz",
-                    "email": "joel.wurtz@gmail.com"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Promise used for asynchronous HTTP requests",
-            "homepage": "http://httplug.io",
-            "keywords": [
-                "promise"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/promise/issues",
-                "source": "https://github.com/php-http/promise/tree/1.3.1"
-            },
-            "time": "2024-03-15T13:55:21+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client"
-            },
-            "time": "2023-09-23T14:17:50+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory"
-            },
-            "time": "2024-04-15T12:06:14+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "wordpress/php-ai-client",
-            "version": "0.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "48cc7de403e00d3035ce2fcb88128dea5e283444"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/48cc7de403e00d3035ce2fcb88128dea5e283444",
-                "reference": "48cc7de403e00d3035ce2fcb88128dea5e283444",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=7.4",
-                "php-http/discovery": "^1.0",
-                "php-http/httplug": "^2.0",
-                "php-http/message-factory": "^1.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "guzzlehttp/psr7": "^1.0 || ^2.0",
-                "php-http/curl-client": "^2.0",
-                "php-http/mock-client": "^1.0",
-                "phpcompatibility/php-compatibility": "dev-develop",
-                "phpstan/phpstan": "~2.1",
-                "phpunit/phpunit": "^9.5 || ^10.0",
-                "slevomat/coding-standard": "^8.20",
-                "squizlabs/php_codesniffer": "^3.7"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/polyfills.php"
-                ],
-                "psr-4": {
-                    "WordPress\\AiClient\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "WordPress AI Team",
-                    "homepage": "https://make.wordpress.org/ai/"
-                }
-            ],
-            "description": "A provider agnostic PHP AI client SDK to communicate with any generative AI models of various capabilities using a uniform API.",
-            "homepage": "https://github.com/WordPress/php-ai-client",
-            "keywords": [
-                "ai",
-                "api",
-                "llm"
-            ],
-            "support": {
-                "issues": "https://github.com/WordPress/php-ai-client/issues",
-                "source": "https://github.com/WordPress/php-ai-client"
-            },
-            "time": "2025-12-08T03:41:36+00:00"
-        }
-    ],
+    "content-hash": "f7930401c2fbad260ecf347172d7e9fe",
+    "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -946,16 +475,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.0",
+            "version": "v6.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a"
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
-                "reference": "5171cb6650e6c583a96943fd6ea0dfa3e1089a8a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
                 "shasum": ""
             },
             "conflict": {
@@ -966,9 +495,10 @@
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -991,9 +521,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
             },
-            "time": "2025-12-03T23:06:24+00:00"
+            "time": "2026-02-03T19:29:21+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -1220,11 +750,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.54",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -1269,7 +799,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1594,16 +1124,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.62",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3f7dd5066ebde5809296a81f0b19e8b00e5aab49"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3f7dd5066ebde5809296a81f0b19e8b00e5aab49",
-                "reference": "3f7dd5066ebde5809296a81f0b19e8b00e5aab49",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
@@ -1675,7 +1205,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.62"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1699,7 +1229,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:32:38+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2914,16 +2444,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.0",
+            "version": "6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340"
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/448dc57a97c7225d2ac6271876682fca4c2ed340",
-                "reference": "448dc57a97c7225d2ac6271876682fca4c2ed340",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15fd216bf6516670d8d07b938675925bfa5c15b0",
+                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0",
                 "shasum": ""
             },
             "type": "library",
@@ -2958,7 +2488,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2025-12-03T01:19:46+00:00"
+            "time": "2026-02-04T01:48:23+00:00"
         }
     ],
     "aliases": [],
@@ -2973,5 +2503,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/class-health-controller.php
+++ b/includes/class-health-controller.php
@@ -77,8 +77,9 @@ class Health_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_health(): WP_REST_Response {
-		$ai_available = class_exists( 'WordPress\AiClient\AiClient' );
-		$notes_api    = version_compare( get_bloginfo( 'version' ), '6.9', '>=' );
+		$ai_available = function_exists( 'wp_ai_client_prompt' );
+		$wp_version   = get_bloginfo( 'version' );
+		$notes_api    = version_compare( $wp_version, '7.0', '>=' );
 
 		$status = ( $ai_available && $notes_api ) ? 'ok' : 'degraded';
 
@@ -89,7 +90,7 @@ class Health_Controller extends WP_REST_Controller {
 				'ai_available' => $ai_available,
 				'notes_api'    => $notes_api,
 				'php_version'  => PHP_VERSION,
-				'wp_version'   => get_bloginfo( 'version' ),
+				'wp_version'   => $wp_version,
 			)
 		);
 	}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -150,10 +150,11 @@ class Plugin {
 			'ai-feedback-editor',
 			'aiFeedbackData',
 			array(
-				'restUrl'   => rest_url( 'ai-feedback/v1' ),
-				'nonce'     => wp_create_nonce( 'wp_rest' ),
-				'version'   => AI_FEEDBACK_VERSION,
-				'pluginUrl' => AI_FEEDBACK_PLUGIN_URL,
+				'restUrl'       => rest_url( 'ai-feedback/v1' ),
+				'nonce'         => wp_create_nonce( 'wp_rest' ),
+				'version'       => AI_FEEDBACK_VERSION,
+				'pluginUrl'     => AI_FEEDBACK_PLUGIN_URL,
+				'connectorsUrl' => admin_url( 'options-general.php?page=connectors' ),
 			)
 		);
 

--- a/includes/class-review-service.php
+++ b/includes/class-review-service.php
@@ -41,7 +41,6 @@ class Review_Service {
 	 * @var array
 	 */
 	const NON_RETRYABLE_ERRORS = array(
-		'rate_limit_exceeded',
 		'invalid_api_key',
 		'billing_error',
 		'rest_forbidden',
@@ -411,8 +410,23 @@ class Review_Service {
 		}
 
 		$message = strtolower( (string) $error->get_error_message() );
-		foreach ( self::NON_RETRYABLE_MESSAGE_KEYWORDS as $keyword ) {
-			if ( '' !== $message && str_contains( $message, $keyword ) ) {
+		if ( '' === $message ) {
+			return false;
+		}
+
+		/**
+		 * Filters the message-keyword fallback used to classify errors as
+		 * non-retryable when their code does not match.
+		 *
+		 * @param string[] $keywords Lowercase substrings to match.
+		 */
+		$keywords = (array) apply_filters(
+			'ai_feedback_non_retryable_message_keywords',
+			self::NON_RETRYABLE_MESSAGE_KEYWORDS
+		);
+
+		foreach ( $keywords as $keyword ) {
+			if ( str_contains( $message, $keyword ) ) {
 				return true;
 			}
 		}

--- a/includes/class-review-service.php
+++ b/includes/class-review-service.php
@@ -44,7 +44,6 @@ class Review_Service {
 		'rate_limit_exceeded',
 		'invalid_api_key',
 		'billing_error',
-		'http_request_failed',
 		'rest_forbidden',
 	);
 
@@ -282,8 +281,8 @@ class Review_Service {
 		 *
 		 * @param int $timeout Timeout in seconds. Default 60.
 		 */
-		$timeout         = (int) apply_filters( 'ai_feedback_http_timeout', self::AI_HTTP_TIMEOUT );
-		$timeout_filter  = static function () use ( $timeout ) {
+		$timeout        = (int) apply_filters( 'ai_feedback_http_timeout', self::AI_HTTP_TIMEOUT );
+		$timeout_filter = static function () use ( $timeout ) {
 			return $timeout;
 		};
 		add_filter( 'http_request_timeout', $timeout_filter, PHP_INT_MAX );
@@ -297,6 +296,11 @@ class Review_Service {
 				->using_temperature( 0.3 )
 				->using_max_tokens( 8000 )
 				->generate_text();
+		} catch ( \Throwable $e ) {
+			// Defensive: the core AI Client should already convert SDK
+			// exceptions to WP_Error, but transport-level throws would
+			// otherwise propagate as a 500 with no useful body.
+			return new WP_Error( 'ai_request_failed', $e->getMessage() );
 		} finally {
 			remove_filter( 'http_request_timeout', $timeout_filter, PHP_INT_MAX );
 		}

--- a/includes/class-review-service.php
+++ b/includes/class-review-service.php
@@ -19,11 +19,24 @@ class Review_Service {
 
 
 	/**
+	 * HTTP request timeout (seconds) applied while calling the AI Client.
+	 *
+	 * Default WordPress HTTP timeout is 5 seconds, which is well below the
+	 * latency budget of an AI generation. Tunable via the
+	 * `ai_feedback_http_timeout` filter.
+	 *
+	 * @var int
+	 */
+	const AI_HTTP_TIMEOUT = 60;
+
+	/**
 	 * Non-retryable error codes that should fail immediately without retry.
 	 *
 	 * Codes are matched against the WP_Error returned by
-	 * wp_ai_client_prompt()->generate_text(). Unknown codes fall through to
-	 * the retry path, which is the safer default for transient failures.
+	 * wp_ai_client_prompt()->generate_text(). The defaults cover both the
+	 * codes the plugin used historically and a broader set likely to surface
+	 * from core's HTTP transport / AI Client. Adopters can extend the list
+	 * via the `ai_feedback_non_retryable_errors` filter.
 	 *
 	 * @var array
 	 */
@@ -31,6 +44,25 @@ class Review_Service {
 		'rate_limit_exceeded',
 		'invalid_api_key',
 		'billing_error',
+		'http_request_failed',
+		'rest_forbidden',
+	);
+
+	/**
+	 * Substrings that indicate a permanent (non-retryable) failure when found
+	 * in an error message, regardless of the error code. This is a defensive
+	 * fallback for cases where the core AI Client reports auth/billing
+	 * failures under a generic code.
+	 *
+	 * @var array
+	 */
+	const NON_RETRYABLE_MESSAGE_KEYWORDS = array(
+		'invalid api key',
+		'unauthorized',
+		'authentication',
+		'billing',
+		'quota',
+		'insufficient',
 	);
 
 	/**
@@ -227,9 +259,10 @@ class Review_Service {
 	/**
 	 * Call AI service via the WordPress 7.0 core AI Client.
 	 *
-	 * Request timeouts are owned by the WordPress HTTP transport that the
-	 * core AI Client uses internally; they can be tuned globally via the
-	 * `http_request_timeout` filter rather than per-call here.
+	 * Wraps the request with a scoped `http_request_timeout` filter so the
+	 * WordPress HTTP transport waits long enough for AI generation. The
+	 * filter is removed immediately after the call so it does not affect
+	 * other HTTP requests in the same pageload.
 	 *
 	 * @param  string $prompt             User prompt.
 	 * @param  string $system_instruction System instruction.
@@ -244,14 +277,29 @@ class Review_Service {
 			);
 		}
 
-		// Lower temperature keeps feedback consistent. Max tokens covers large
-		// documents while staying within all supported models' limits.
-		return wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $system_instruction )
-			->using_model_preference( $model )
-			->using_temperature( 0.3 )
-			->using_max_tokens( 8000 )
-			->generate_text();
+		/**
+		 * Filters the HTTP timeout (in seconds) used for AI generation requests.
+		 *
+		 * @param int $timeout Timeout in seconds. Default 60.
+		 */
+		$timeout         = (int) apply_filters( 'ai_feedback_http_timeout', self::AI_HTTP_TIMEOUT );
+		$timeout_filter  = static function () use ( $timeout ) {
+			return $timeout;
+		};
+		add_filter( 'http_request_timeout', $timeout_filter, PHP_INT_MAX );
+
+		try {
+			// Lower temperature keeps feedback consistent. Max tokens covers large
+			// documents while staying within all supported models' limits.
+			return wp_ai_client_prompt( $prompt )
+				->using_system_instruction( $system_instruction )
+				->using_model_preference( $model )
+				->using_temperature( 0.3 )
+				->using_max_tokens( 8000 )
+				->generate_text();
+		} finally {
+			remove_filter( 'http_request_timeout', $timeout_filter, PHP_INT_MAX );
+		}
 	}
 
 	/**
@@ -301,7 +349,7 @@ class Review_Service {
 			$error_code = $response->get_error_code();
 
 			// Check if error is non-retryable - fail immediately.
-			if ( in_array( $error_code, self::NON_RETRYABLE_ERRORS, true ) ) {
+			if ( $this->is_non_retryable_error( $response ) ) {
 				Logger::debug(
 					sprintf(
 						'Non-retryable error encountered: %s - %s',
@@ -331,6 +379,41 @@ class Review_Service {
 			)
 		);
 		return $last_error;
+	}
+
+	/**
+	 * Whether a WP_Error returned by the AI Client should fail fast.
+	 *
+	 * Matches both error codes and error message keywords so that
+	 * permanently-failing requests (auth, billing, quota) bypass the retry
+	 * loop even when core wraps them under a generic code.
+	 *
+	 * @param  WP_Error $error The error returned by the AI Client.
+	 * @return bool True when the request should not be retried.
+	 */
+	protected function is_non_retryable_error( WP_Error $error ): bool {
+		/**
+		 * Filters the list of error codes treated as non-retryable.
+		 *
+		 * @param string[] $codes Error codes that should fail immediately.
+		 */
+		$codes = (array) apply_filters(
+			'ai_feedback_non_retryable_errors',
+			self::NON_RETRYABLE_ERRORS
+		);
+
+		if ( in_array( $error->get_error_code(), $codes, true ) ) {
+			return true;
+		}
+
+		$message = strtolower( (string) $error->get_error_message() );
+		foreach ( self::NON_RETRYABLE_MESSAGE_KEYWORDS as $keyword ) {
+			if ( '' !== $message && str_contains( $message, $keyword ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-review-service.php
+++ b/includes/class-review-service.php
@@ -21,6 +21,10 @@ class Review_Service {
 	/**
 	 * Non-retryable error codes that should fail immediately without retry.
 	 *
+	 * Codes are matched against the WP_Error returned by
+	 * wp_ai_client_prompt()->generate_text(). Unknown codes fall through to
+	 * the retry path, which is the safer default for transient failures.
+	 *
 	 * @var array
 	 */
 	const NON_RETRYABLE_ERRORS = array(
@@ -222,6 +226,10 @@ class Review_Service {
 
 	/**
 	 * Call AI service via the WordPress 7.0 core AI Client.
+	 *
+	 * Request timeouts are owned by the WordPress HTTP transport that the
+	 * core AI Client uses internally; they can be tuned globally via the
+	 * `http_request_timeout` filter rather than per-call here.
 	 *
 	 * @param  string $prompt             User prompt.
 	 * @param  string $system_instruction System instruction.

--- a/includes/class-review-service.php
+++ b/includes/class-review-service.php
@@ -10,8 +10,6 @@
 namespace AI_Feedback;
 
 use WP_Error;
-use WordPress\AiClient\AiClient;
-use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use AI_Feedback\Logger;
 
 /**
@@ -223,7 +221,7 @@ class Review_Service {
 	}
 
 	/**
-	 * Call AI service.
+	 * Call AI service via the WordPress 7.0 core AI Client.
 	 *
 	 * @param  string $prompt             User prompt.
 	 * @param  string $system_instruction System instruction.
@@ -231,41 +229,21 @@ class Review_Service {
 	 * @return string|WP_Error AI response or error.
 	 */
 	protected function call_ai( string $prompt, string $system_instruction, string $model ): string|WP_Error {
-		// Check if PHP AI Client is available.
-		if ( ! class_exists( 'WordPress\AiClient\AiClient' ) ) {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return new WP_Error(
 				'ai_client_missing',
-				__( 'PHP AI Client library is not installed. Please run: composer install', 'ai-feedback' )
+				__( 'The WordPress core AI Client is unavailable. WordPress 7.0 or higher is required.', 'ai-feedback' )
 			);
 		}
 
-		try {
-			// Create request options with timeout.
-			$request_options = new RequestOptions();
-			$request_options->setTimeout( 60.0 ); // 60 second timeout.
-
-			// Call AI using WordPress PHP AI Client.
-			$response = AiClient::prompt( $prompt )
-				->usingSystemInstruction( $system_instruction )
-				->usingModelPreference( $model )
-				->usingTemperature( 0.3 ) // Lower temperature for consistent feedback.
-				->usingMaxTokens( 8000 ) // Sufficient for large documents; within limits of all supported models.
-				->usingRequestOptions( $request_options )
-				->generateText();
-
-			return $response;
-
-		} catch ( \Exception $e ) {
-			$error_code = $this->extract_error_code_from_exception( $e );
-			return new WP_Error(
-				$error_code,
-				sprintf(
-				/* translators: %s: error message */
-					__( 'AI request failed: %s', 'ai-feedback' ),
-					$e->getMessage()
-				)
-			);
-		}
+		// Lower temperature keeps feedback consistent. Max tokens covers large
+		// documents while staying within all supported models' limits.
+		return wp_ai_client_prompt( $prompt )
+			->using_system_instruction( $system_instruction )
+			->using_model_preference( $model )
+			->using_temperature( 0.3 )
+			->using_max_tokens( 8000 )
+			->generate_text();
 	}
 
 	/**
@@ -345,52 +323,6 @@ class Review_Service {
 			)
 		);
 		return $last_error;
-	}
-
-	/**
-	 * Extract error code from exception.
-	 *
-	 * Attempts to identify specific error types from exception messages
-	 * or exception class names for better retry handling.
-	 *
-	 * @param  \Exception $e The exception to analyze.
-	 * @return string Error code for WP_Error.
-	 */
-	protected function extract_error_code_from_exception( \Exception $e ): string {
-		$message    = strtolower( $e->getMessage() );
-		$class_name = strtolower( get_class( $e ) );
-
-		// Check for rate limiting errors.
-		if ( str_contains( $message, 'rate limit' )
-			|| str_contains( $message, 'rate_limit' )
-			|| str_contains( $message, 'too many requests' )
-			|| str_contains( $class_name, 'ratelimit' )
-		) {
-			return 'rate_limit_exceeded';
-		}
-
-		// Check for authentication errors.
-		if ( str_contains( $message, 'invalid api key' )
-			|| str_contains( $message, 'invalid_api_key' )
-			|| str_contains( $message, 'unauthorized' )
-			|| str_contains( $message, 'authentication' )
-			|| str_contains( $class_name, 'authentication' )
-			|| str_contains( $class_name, 'unauthorized' )
-		) {
-			return 'invalid_api_key';
-		}
-
-		// Check for billing errors.
-		if ( str_contains( $message, 'billing' )
-			|| str_contains( $message, 'payment' )
-			|| str_contains( $message, 'quota exceeded' )
-			|| str_contains( $message, 'insufficient' )
-		) {
-			return 'billing_error';
-		}
-
-		// Default to generic error code.
-		return 'ai_request_failed';
 	}
 
 	/**

--- a/includes/class-settings-controller.php
+++ b/includes/class-settings-controller.php
@@ -88,27 +88,33 @@ class Settings_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response Status response.
 	 */
 	public function get_status(): \WP_REST_Response {
-		$ai_client_available = function_exists( 'wp_ai_client_prompt' );
-
-		// Detect whether at least one AI provider connector is configured via
-		// the WordPress 7.0 Connectors API.
-		$connector_configured = false;
-		if ( function_exists( 'wp_get_connectors' ) ) {
-			foreach ( wp_get_connectors() as $connector ) {
-				if ( ( $connector['type'] ?? '' ) === 'ai_provider' ) {
-					$connector_configured = true;
-					break;
-				}
-			}
-		}
-
 		$status = array(
-			'ai_client_available'  => $ai_client_available,
-			'connector_configured' => $connector_configured,
+			'ai_client_available'  => function_exists( 'wp_ai_client_prompt' ),
+			'connector_configured' => $this->has_ai_provider_connector(),
 			'settings_url'         => admin_url( 'options-general.php?page=connectors' ),
 		);
 
 		return rest_ensure_response( $status );
+	}
+
+	/**
+	 * Whether at least one AI provider connector is registered with the
+	 * WordPress 7.0 Connectors API.
+	 *
+	 * @return bool True when an `ai_provider` connector exists.
+	 */
+	protected function has_ai_provider_connector(): bool {
+		if ( ! function_exists( 'wp_get_connectors' ) ) {
+			return false;
+		}
+
+		foreach ( wp_get_connectors() as $connector ) {
+			if ( ( $connector['type'] ?? '' ) === 'ai_provider' ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-settings-controller.php
+++ b/includes/class-settings-controller.php
@@ -88,11 +88,24 @@ class Settings_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response Status response.
 	 */
 	public function get_status(): \WP_REST_Response {
-		$ai_client_available = class_exists( 'WordPress\AiClient\AiClient' );
+		$ai_client_available = function_exists( 'wp_ai_client_prompt' );
+
+		// Detect whether at least one AI provider connector is configured via
+		// the WordPress 7.0 Connectors API.
+		$connector_configured = false;
+		if ( function_exists( 'wp_get_connectors' ) ) {
+			foreach ( wp_get_connectors() as $connector ) {
+				if ( ( $connector['type'] ?? '' ) === 'ai_provider' ) {
+					$connector_configured = true;
+					break;
+				}
+			}
+		}
 
 		$status = array(
-			'ai_client_available' => $ai_client_available,
-			'settings_url'        => admin_url( 'options-general.php?page=wp-ai-client' ),
+			'ai_client_available'  => $ai_client_available,
+			'connector_configured' => $connector_configured,
+			'settings_url'         => admin_url( 'options-general.php?page=connectors' ),
 		);
 
 		return rest_ensure_response( $status );

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -5,6 +5,11 @@
  *
  * Loaded only by PHPStan; never executed at runtime.
  *
+ * TODO: Remove this file once php-stubs/wordpress-stubs ships v7.0.x and
+ * Composer is bumped to require it; the upstream stubs will provide the
+ * real signatures for wp_ai_client_prompt(), WP_AI_Client_Prompt_Builder,
+ * wp_get_connectors(), wp_get_connector(), and wp_is_connector_registered().
+ *
  * @package AI_Feedback
  */
 

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Stub file for WordPress 7.0 functions and classes that are not yet
+ * available in php-stubs/wordpress-stubs (pinned to 6.9.x).
+ *
+ * Loaded only by PHPStan; never executed at runtime.
+ *
+ * @package AI_Feedback
+ */
+
+// phpcs:disable
+
+if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+	/**
+	 * @param string $prompt Optional prompt text.
+	 * @return WP_AI_Client_Prompt_Builder
+	 */
+	function wp_ai_client_prompt( string $prompt = '' ): WP_AI_Client_Prompt_Builder {
+		return new WP_AI_Client_Prompt_Builder();
+	}
+}
+
+if ( ! function_exists( 'wp_get_connectors' ) ) {
+	/**
+	 * @return array<string, array{name?: string, description?: string, type?: string, plugin?: array<string,mixed>}>
+	 */
+	function wp_get_connectors(): array {
+		return array();
+	}
+}
+
+if ( ! function_exists( 'wp_get_connector' ) ) {
+	/**
+	 * @param string $id Connector ID.
+	 * @return array<string,mixed>|null
+	 */
+	function wp_get_connector( string $id ): ?array {
+		return null;
+	}
+}
+
+if ( ! function_exists( 'wp_is_connector_registered' ) ) {
+	function wp_is_connector_registered( string $id ): bool {
+		return false;
+	}
+}
+
+if ( ! class_exists( 'WP_AI_Client_Prompt_Builder' ) ) {
+	/**
+	 * Fluent prompt builder backed by the WordPress 7.0 core AI Client.
+	 */
+	class WP_AI_Client_Prompt_Builder {
+		public function with_text( string $text ): self {
+			return $this;
+		}
+		public function using_system_instruction( string $instruction ): self {
+			return $this;
+		}
+		public function using_temperature( float $temperature ): self {
+			return $this;
+		}
+		public function using_max_tokens( int $max_tokens ): self {
+			return $this;
+		}
+		public function using_top_p( float $top_p ): self {
+			return $this;
+		}
+		public function using_top_k( int $top_k ): self {
+			return $this;
+		}
+		/**
+		 * @param string ...$models
+		 */
+		public function using_model_preference( string ...$models ): self {
+			return $this;
+		}
+		/**
+		 * @param array<string,mixed> $schema
+		 */
+		public function as_json_response( array $schema ): self {
+			return $this;
+		}
+		/**
+		 * @return string|WP_Error
+		 */
+		public function generate_text() {
+			return '';
+		}
+		public function is_supported_for_text_generation(): bool {
+			return true;
+		}
+	}
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,8 @@ parameters:
         - ai-feedback.php
     scanFiles:
         - ai-feedback.php
+    bootstrapFiles:
+        - phpstan-stubs.php
     excludePaths:
         - vendor/ (?)
         - node_modules/ (?)

--- a/readme.txt
+++ b/readme.txt
@@ -1,89 +1,72 @@
 === AI Feedback ===
 Contributors: adamsilverstein
 Tags: ai, gutenberg, feedback, block-editor, notes
-Requires at least: 6.9
-Tested up to: 6.9
-Requires PHP: 8.0
-Stable tag: 0.1.0
+Requires at least: 7.0
+Tested up to: 7.0
+Requires PHP: 8.1
+Stable tag: 0.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-AI-powered editorial feedback for WordPress Gutenberg editor using WordPress 6.9's Notes feature.
+AI-powered editorial feedback for WordPress Gutenberg, built on WordPress 7.0's core AI Client, Connectors API, and Notes feature.
 
 == Description ==
 
-The AI Feedback plugin integrates AI-powered content review directly into the WordPress block editor. It leverages the native Notes API (WordPress 6.9+) to provide contextual, block-level feedback on your content.
+The AI Feedback plugin integrates AI-powered content review directly into the WordPress block editor. It leverages the WordPress 7.0 core AI Client and Connectors API for provider-agnostic AI access, and uses the native Notes API to provide contextual, block-level feedback on your content.
 
 = Features =
 
-* 🤖 **AI-Powered Reviews**: Get intelligent feedback on content quality, tone, flow, and design
+* 🤖 **AI-Powered Reviews**: Intelligent feedback on content quality, tone, flow, and design
 * 📝 **Native Notes Integration**: Feedback appears as WordPress block comments
-* ⚙️ **Configurable Settings**: Choose AI models, focus areas, and target tone
-* 🔄 **Multiple AI Providers**: Support for Claude, GPT-4, Gemini, and more
+* 🔌 **Core Connectors API**: Uses the credentials you've already configured in Settings → Connectors
+* 🔄 **Multiple AI Providers**: Works with Anthropic, OpenAI, Google, and any other registered AI provider
 * 🎯 **Focus Areas**: Content Quality, Tone & Voice, Flow & Structure, Design & Formatting
 
 = Requirements =
 
-* **WordPress**: 6.9 or higher
-* **PHP**: 8.0 or higher
-* **Plugins**: [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/)
+* **WordPress**: 7.0 or higher
+* **PHP**: 8.1 or higher
+* **AI Provider**: At least one provider configured under Settings → Connectors
 
 == Installation ==
 
 = Prerequisites =
 
-The AI Feedback plugin requires the [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/) to be installed and activated. The AI Experiments plugin provides:
+WordPress 7.0 introduced the core AI Client and Connectors API. AI Feedback uses both directly — there is no longer any custom AI plumbing or separate "AI Experiments" plugin to install.
 
-* Centralized AI settings screen for configuring API keys
-* Support for multiple AI providers (Anthropic, OpenAI, Google Gemini, etc.)
-* Common interface for AI configuration across WordPress plugins
+Before using AI Feedback, configure an AI provider:
 
-**Install the AI Experiments plugin first:**
-
-1. Go to WordPress Admin → Plugins → Add New
-2. Search for "AI Experiments" or "AI"
-3. Click "Install Now" and then "Activate"
-4. Configure your AI provider API keys in Settings → AI
+1. In WordPress admin, go to **Settings → Connectors**.
+2. Pick a provider (Anthropic, OpenAI, Google, etc.) and add an API key, or define one as an environment variable / PHP constant.
+3. Save.
 
 = Installing AI Feedback =
 
-1. Download the plugin from the WordPress plugin directory
-2. Upload the plugin files to `/wp-content/plugins/ai-feedback/`, or install via the WordPress plugins screen
-3. Activate the plugin through the 'Plugins' screen in WordPress
-4. Configure your AI provider in Settings → AI
-5. Open a post in the block editor and look for the AI Feedback panel
+1. Upload the plugin to `/wp-content/plugins/ai-feedback/`, or install via the WordPress plugins screen.
+2. Activate the plugin through the **Plugins** screen.
+3. Open any post in the block editor — the AI Feedback panel appears in the sidebar.
 
 == Frequently Asked Questions ==
 
 = What AI providers are supported? =
 
-The plugin supports any AI provider configured via the WordPress AI Experiments plugin, including:
-* Anthropic Claude
-* OpenAI GPT
-* Google Gemini
-* And more
+Any provider registered with the WordPress 7.0 core AI Client. Out of the box this includes Anthropic, OpenAI, and Google. Additional providers can be added by their respective AI provider plugins.
 
-= Do I need an API key? =
+= Where do I configure my API key? =
 
-Yes, you'll need an API key from your chosen AI provider. Configure it in the WordPress AI Experiments plugin settings at Settings → AI.
+Settings → Connectors. The Connectors API also supports environment variables (e.g. `ANTHROPIC_API_KEY`) and PHP constants for credentials, taking precedence over database-stored values.
 
 = What version of WordPress do I need? =
 
-WordPress 6.9 or higher is required for the Notes feature that powers the block-level feedback.
+WordPress 7.0 or higher. Earlier versions are not supported because the plugin relies on `wp_ai_client_prompt()` and the Connectors API.
 
 = Can I customize the feedback focus areas? =
 
-Yes! The plugin provides several focus areas:
-* Content Quality
-* Tone & Voice
-* Flow & Structure
-* Design & Formatting
-
-You can select which areas you want the AI to focus on for each review.
+Yes. The plugin provides Content Quality, Tone & Voice, Flow & Structure, and Design & Formatting focus areas, and you can pick which ones to apply per review.
 
 = Is my content sent to external services? =
 
-Yes, your content is sent to your configured AI provider (Anthropic, OpenAI, Google, etc.) for analysis. Please review your AI provider's privacy policy and terms of service.
+Yes — your content is sent to whichever AI provider you've configured in Settings → Connectors. Please review your provider's privacy policy and terms of service.
 
 == Screenshots ==
 
@@ -94,28 +77,34 @@ Yes, your content is sent to your configured AI provider (Anthropic, OpenAI, Goo
 
 == Changelog ==
 
+= 0.2.0 =
+* Migrated to the WordPress 7.0 core AI Client (`wp_ai_client_prompt()`).
+* Adopted the WordPress 7.0 Connectors API for credential management; the AI Experiments plugin is no longer required.
+* Bumped minimum requirements to WordPress 7.0 and PHP 8.1.
+* Removed the `wordpress/php-ai-client` Composer dependency.
+* Updated onboarding and error messaging to point users at Settings → Connectors.
+
 = 0.1.0 =
-* Initial release
-* Plugin scaffold with build system
-* Settings UI and REST API
-* Model selection with provider grouping
-* Focus areas and tone selection
-* Review button with loading states
+* Initial release.
+* Plugin scaffold with build system.
+* Settings UI and REST API.
+* Model selection with provider grouping.
+* Focus areas and tone selection.
+* Review button with loading states.
 
 == Upgrade Notice ==
 
-= 0.1.0 =
-Initial release of AI Feedback plugin. Requires WordPress 6.9+ and the AI Experiments plugin.
+= 0.2.0 =
+Now requires WordPress 7.0+ and PHP 8.1+. AI provider credentials are read from Settings → Connectors; the previous AI Experiments plugin dependency has been removed.
 
 == Development ==
 
 The plugin is actively developed on GitHub:
 https://github.com/adamsilverstein/ai-feedback
 
-Contributions are welcome!
+Contributions are welcome.
 
 == Credits ==
 
-* Requires [WordPress AI Experiments plugin](https://wordpress.org/plugins/ai/)
-* Built with [WordPress PHP AI Client](https://github.com/WordPress/php-ai-client)
-* Uses WordPress 6.9+ Notes API
+* Built on the WordPress 7.0 core [AI Client](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/) and [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/)
+* Uses the WordPress Notes API for block-level comments

--- a/src/components/AIFeedbackPanel.js
+++ b/src/components/AIFeedbackPanel.js
@@ -19,9 +19,9 @@ import WelcomeModal from './WelcomeModal';
 import SkipLinks from './SkipLinks';
 
 /**
- * Settings page URL.
+ * URL of the WordPress 7.0 Connectors admin screen.
  */
-const SETTINGS_PAGE_URL = '/wp-admin/admin.php?page=ai-feedback-settings';
+const CONNECTORS_PAGE_URL = '/wp-admin/options-general.php?page=connectors';
 
 /**
  * Get action button for specific error types.
@@ -30,11 +30,9 @@ const SETTINGS_PAGE_URL = '/wp-admin/admin.php?page=ai-feedback-settings';
  * @return {Element|null} Action button or null.
  */
 function getErrorAction(error) {
-	// Check if error is related to API credits or billing.
-	// Note: We use string matching on error messages because the PHP AI Client
-	// wraps all AI provider errors under the same 'ai_request_failed' code.
-	// Credit/billing errors from providers (Anthropic, OpenAI) typically include
-	// these keywords in a stable format.
+	// Credit/billing errors typically surface via the core AI Client wrapper
+	// using the generic ai_request_failed code; match on keywords so users get
+	// a direct link to the Connectors screen where credentials are managed.
 	if (
 		error.code === 'ai_request_failed' &&
 		typeof error.message === 'string' &&
@@ -44,12 +42,12 @@ function getErrorAction(error) {
 		return (
 			<Button
 				variant="link"
-				href={SETTINGS_PAGE_URL}
+				href={CONNECTORS_PAGE_URL}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="ai-feedback-error-action"
 			>
-				{__('Go to Settings', 'ai-feedback')}
+				{__('Open Connectors Settings', 'ai-feedback')}
 			</Button>
 		);
 	}

--- a/src/components/AIFeedbackPanel.js
+++ b/src/components/AIFeedbackPanel.js
@@ -8,6 +8,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { STORE_NAME } from '../store';
 import { hasTextContent, extractBlockData } from '../utils/block-utils';
+import { getConnectorsUrl } from '../utils/connectors-url';
 
 import ModelSelector from './ModelSelector';
 import LanguageSelector from './LanguageSelector';
@@ -17,11 +18,6 @@ import EmptyState from './EmptyState';
 import StatusAnnouncer from './StatusAnnouncer';
 import WelcomeModal from './WelcomeModal';
 import SkipLinks from './SkipLinks';
-
-/**
- * URL of the WordPress 7.0 Connectors admin screen.
- */
-const CONNECTORS_PAGE_URL = '/wp-admin/options-general.php?page=connectors';
 
 /**
  * Get action button for specific error types.
@@ -42,7 +38,7 @@ function getErrorAction(error) {
 		return (
 			<Button
 				variant="link"
-				href={CONNECTORS_PAGE_URL}
+				href={getConnectorsUrl()}
 				target="_blank"
 				rel="noopener noreferrer"
 				className="ai-feedback-error-action"

--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -11,7 +11,7 @@ import { check, pencil, commentContent } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 const STORAGE_KEY = 'ai-feedback-welcomed';
-const AI_SETTINGS_URL = '/wp-admin/options-general.php?page=wp-ai-client';
+const AI_SETTINGS_URL = '/wp-admin/options-general.php?page=connectors';
 
 /**
  * WelcomeModal component shown on first sidebar open.
@@ -118,7 +118,7 @@ export default function WelcomeModal() {
 					<Notice status="warning" isDismissible={false}>
 						<p>
 							{__(
-								'The WordPress AI Experiments plugin must be installed and configured before using AI Feedback.',
+								'AI Feedback uses the WordPress core AI Client. Configure an AI provider in Settings → Connectors before continuing.',
 								'ai-feedback'
 							)}
 						</p>
@@ -131,7 +131,7 @@ export default function WelcomeModal() {
 								<Icon icon={pencil} />
 								<span>
 									{__(
-										'Install the WordPress AI Experiments plugin',
+										'Open Settings → Connectors in WordPress admin',
 										'ai-feedback'
 									)}
 								</span>
@@ -140,7 +140,7 @@ export default function WelcomeModal() {
 								<Icon icon={check} />
 								<span>
 									{__(
-										'Configure an AI provider (OpenAI, Anthropic, or Google)',
+										'Configure an AI provider (Anthropic, OpenAI, or Google)',
 										'ai-feedback'
 									)}
 								</span>
@@ -164,7 +164,7 @@ export default function WelcomeModal() {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{__('Configure AI Settings', 'ai-feedback')}
+							{__('Open Connectors Settings', 'ai-feedback')}
 						</Button>
 						<Button
 							variant="secondary"

--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -9,9 +9,9 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { check, pencil, commentContent } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
+import { getConnectorsUrl } from '../utils/connectors-url';
 
 const STORAGE_KEY = 'ai-feedback-welcomed';
-const AI_SETTINGS_URL = '/wp-admin/options-general.php?page=connectors';
 
 /**
  * WelcomeModal component shown on first sidebar open.
@@ -23,7 +23,7 @@ export default function WelcomeModal() {
 	const [isLoading, setIsLoading] = useState(true);
 	const [aiClientAvailable, setAiClientAvailable] = useState(null);
 	const [statusError, setStatusError] = useState(null);
-	const [settingsUrl, setSettingsUrl] = useState(AI_SETTINGS_URL);
+	const [settingsUrl, setSettingsUrl] = useState(getConnectorsUrl());
 
 	useEffect(() => {
 		// Check if already welcomed first.

--- a/src/components/WelcomeModal.js
+++ b/src/components/WelcomeModal.js
@@ -21,9 +21,8 @@ const STORAGE_KEY = 'ai-feedback-welcomed';
 export default function WelcomeModal() {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
-	const [aiClientAvailable, setAiClientAvailable] = useState(null);
+	const [status, setStatus] = useState(null);
 	const [statusError, setStatusError] = useState(null);
-	const [settingsUrl, setSettingsUrl] = useState(getConnectorsUrl());
 
 	useEffect(() => {
 		// Check if already welcomed first.
@@ -37,13 +36,10 @@ export default function WelcomeModal() {
 			// Ignore localStorage errors, continue with status check.
 		}
 
-		// Check AI client status before showing modal.
+		// Check AI client + connector status before showing modal.
 		apiFetch({ path: '/ai-feedback/v1/status' })
 			.then((response) => {
-				setAiClientAvailable(response.ai_client_available);
-				if (response.settings_url) {
-					setSettingsUrl(response.settings_url);
-				}
+				setStatus(response);
 				setIsOpen(true);
 				setIsLoading(false);
 			})
@@ -57,9 +53,14 @@ export default function WelcomeModal() {
 			});
 	}, []);
 
+	const aiClientAvailable = status?.ai_client_available === true;
+	const connectorConfigured = status?.connector_configured === true;
+	const setupRequired = !aiClientAvailable || !connectorConfigured;
+	const settingsUrl = status?.settings_url || getConnectorsUrl();
+
 	const dismiss = () => {
-		// Only save welcomed state if AI client is available.
-		if (aiClientAvailable) {
+		// Only save welcomed state when the plugin is fully configured.
+		if (!setupRequired) {
 			try {
 				window.localStorage.setItem(STORAGE_KEY, 'true');
 			} catch (error) {
@@ -106,8 +107,18 @@ export default function WelcomeModal() {
 		);
 	}
 
-	// Show configuration required message if AI client is not available.
-	if (!aiClientAvailable) {
+	// Show configuration required message if AI client is unavailable or no
+	// AI provider connector is configured yet.
+	if (setupRequired) {
+		const message = !aiClientAvailable
+			? __(
+					'AI Feedback requires the WordPress 7.0 core AI Client. Update WordPress to continue.',
+					'ai-feedback'
+				)
+			: __(
+					'AI Feedback uses the WordPress core AI Client. Configure an AI provider in Settings → Connectors before continuing.',
+					'ai-feedback'
+				);
 		return (
 			<Modal
 				title={__('AI Feedback Setup Required', 'ai-feedback')}
@@ -116,12 +127,7 @@ export default function WelcomeModal() {
 			>
 				<div className="ai-feedback-welcome">
 					<Notice status="warning" isDismissible={false}>
-						<p>
-							{__(
-								'AI Feedback uses the WordPress core AI Client. Configure an AI provider in Settings → Connectors before continuing.',
-								'ai-feedback'
-							)}
-						</p>
+						<p>{message}</p>
 					</Notice>
 
 					<div className="ai-feedback-welcome-prereq">

--- a/src/utils/connectors-url.js
+++ b/src/utils/connectors-url.js
@@ -1,0 +1,11 @@
+/**
+ * URL of the WordPress 7.0 Connectors admin screen, where AI provider
+ * credentials are configured. Localized from PHP via wp_localize_script;
+ * falls back to the default admin path if the global is missing.
+ *
+ * @return {string} Connectors admin URL.
+ */
+export function getConnectorsUrl() {
+	const localized = window.aiFeedbackData?.connectorsUrl;
+	return localized || '/wp-admin/options-general.php?page=connectors';
+}

--- a/src/utils/connectors-url.js
+++ b/src/utils/connectors-url.js
@@ -3,9 +3,22 @@
  * credentials are configured. Localized from PHP via wp_localize_script;
  * falls back to the default admin path if the global is missing.
  *
+ * The fallback assumes the standard `/wp-admin/` location, which can be
+ * wrong on installs that customize WP_ADMIN_DIR or use a subdirectory
+ * setup. We surface a console warning in that case so the misconfigured
+ * environment is easy to spot rather than failing silently.
+ *
  * @return {string} Connectors admin URL.
  */
 export function getConnectorsUrl() {
 	const localized = window.aiFeedbackData?.connectorsUrl;
-	return localized || '/wp-admin/options-general.php?page=connectors';
+	if (localized) {
+		return localized;
+	}
+
+	// eslint-disable-next-line no-console
+	console.warn(
+		'[AI Feedback] aiFeedbackData.connectorsUrl is missing; falling back to the default admin path.'
+	);
+	return '/wp-admin/options-general.php?page=connectors';
 }

--- a/tests/php/ReviewServiceRetryTest.php
+++ b/tests/php/ReviewServiceRetryTest.php
@@ -72,17 +72,6 @@ class TestableReviewService extends Review_Service
     ): string|WP_Error {
         return $this->call_ai_with_retry($prompt, $system_instruction, $model, $max_retries);
     }
-
-    /**
-     * Expose extract_error_code_from_exception for testing.
-     *
-     * @param  \Exception $e Exception to analyze.
-     * @return string Error code.
-     */
-    public function test_extract_error_code( \Exception $e ): string
-    {
-        return $this->extract_error_code_from_exception($e);
-    }
 }
 
 /**
@@ -119,116 +108,6 @@ class ReviewServiceRetryTest extends TestCase
         );
 
         $this->assertSame($expected, Review_Service::NON_RETRYABLE_ERRORS);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with rate limit error.
-     */
-    public function test_extract_error_code_rate_limit(): void
-    {
-        $exception = new \Exception('Rate limit exceeded. Please try again later.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('rate_limit_exceeded', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with rate_limit in message.
-     */
-    public function test_extract_error_code_rate_limit_underscore(): void
-    {
-        $exception = new \Exception('Error: rate_limit reached');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('rate_limit_exceeded', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with too many requests.
-     */
-    public function test_extract_error_code_too_many_requests(): void
-    {
-        $exception = new \Exception('Too many requests. Slow down!');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('rate_limit_exceeded', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with invalid API key.
-     */
-    public function test_extract_error_code_invalid_api_key(): void
-    {
-        $exception = new \Exception('Invalid API key provided.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('invalid_api_key', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with unauthorized.
-     */
-    public function test_extract_error_code_unauthorized(): void
-    {
-        $exception = new \Exception('Unauthorized access to API.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('invalid_api_key', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with authentication error.
-     */
-    public function test_extract_error_code_authentication(): void
-    {
-        $exception = new \Exception('Authentication failed. Check your credentials.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('invalid_api_key', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with billing error.
-     */
-    public function test_extract_error_code_billing(): void
-    {
-        $exception = new \Exception('Billing error: payment method declined.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('billing_error', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with quota exceeded.
-     */
-    public function test_extract_error_code_quota_exceeded(): void
-    {
-        $exception = new \Exception('Quota exceeded for the current billing period.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('billing_error', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with insufficient funds.
-     */
-    public function test_extract_error_code_insufficient(): void
-    {
-        $exception = new \Exception('Insufficient credits remaining.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('billing_error', $code);
-    }
-
-    /**
-     * Test extract_error_code_from_exception with generic error.
-     */
-    public function test_extract_error_code_generic(): void
-    {
-        $exception = new \Exception('Something went wrong on the server.');
-        $code      = $this->service->test_extract_error_code($exception);
-
-        $this->assertSame('ai_request_failed', $code);
     }
 
     /**

--- a/tests/php/ReviewServiceRetryTest.php
+++ b/tests/php/ReviewServiceRetryTest.php
@@ -97,17 +97,17 @@ class ReviewServiceRetryTest extends TestCase
     }
 
     /**
-     * Test that NON_RETRYABLE_ERRORS constant contains expected error codes.
+     * Test that NON_RETRYABLE_ERRORS constant covers the legacy plugin codes
+     * plus the broader set introduced for the WordPress 7.0 core AI Client.
      */
     public function test_non_retryable_errors_constant(): void
     {
-        $expected = array(
-        'rate_limit_exceeded',
-        'invalid_api_key',
-        'billing_error',
-        );
+        $codes = Review_Service::NON_RETRYABLE_ERRORS;
 
-        $this->assertSame($expected, Review_Service::NON_RETRYABLE_ERRORS);
+        $this->assertContains('rate_limit_exceeded', $codes);
+        $this->assertContains('invalid_api_key', $codes);
+        $this->assertContains('billing_error', $codes);
+        $this->assertContains('http_request_failed', $codes);
     }
 
     /**

--- a/tests/php/ReviewServiceRetryTest.php
+++ b/tests/php/ReviewServiceRetryTest.php
@@ -99,6 +99,10 @@ class ReviewServiceRetryTest extends TestCase
     /**
      * Test that NON_RETRYABLE_ERRORS constant covers the legacy plugin codes
      * plus the broader set introduced for the WordPress 7.0 core AI Client.
+     *
+     * `http_request_failed` is intentionally NOT in this list: WordPress uses
+     * it for transient transport failures (timeouts, network glitches) which
+     * should be retried.
      */
     public function test_non_retryable_errors_constant(): void
     {
@@ -107,7 +111,49 @@ class ReviewServiceRetryTest extends TestCase
         $this->assertContains('rate_limit_exceeded', $codes);
         $this->assertContains('invalid_api_key', $codes);
         $this->assertContains('billing_error', $codes);
-        $this->assertContains('http_request_failed', $codes);
+        $this->assertContains('rest_forbidden', $codes);
+        $this->assertNotContains('http_request_failed', $codes);
+    }
+
+    /**
+     * is_non_retryable_error() classifies via error code for known codes.
+     */
+    public function test_is_non_retryable_error_matches_code(): void
+    {
+        $error = new WP_Error('invalid_api_key', 'Some unrelated message');
+
+        $reflection = new ReflectionMethod(Review_Service::class, 'is_non_retryable_error');
+        $reflection->setAccessible(true);
+
+        $this->assertTrue($reflection->invoke($this->service, $error));
+    }
+
+    /**
+     * is_non_retryable_error() falls back to the message keyword check
+     * when core wraps auth/billing failures under a generic code.
+     */
+    public function test_is_non_retryable_error_matches_message_keyword(): void
+    {
+        $error = new WP_Error('ai_request_failed', 'Invalid API key supplied');
+
+        $reflection = new ReflectionMethod(Review_Service::class, 'is_non_retryable_error');
+        $reflection->setAccessible(true);
+
+        $this->assertTrue($reflection->invoke($this->service, $error));
+    }
+
+    /**
+     * is_non_retryable_error() returns false for retryable transient errors
+     * (e.g. http_request_failed timeouts).
+     */
+    public function test_is_non_retryable_error_returns_false_for_transient(): void
+    {
+        $error = new WP_Error('http_request_failed', 'cURL error 28: timeout');
+
+        $reflection = new ReflectionMethod(Review_Service::class, 'is_non_retryable_error');
+        $reflection->setAccessible(true);
+
+        $this->assertFalse($reflection->invoke($this->service, $error));
     }
 
     /**

--- a/tests/php/ReviewServiceRetryTest.php
+++ b/tests/php/ReviewServiceRetryTest.php
@@ -97,21 +97,19 @@ class ReviewServiceRetryTest extends TestCase
     }
 
     /**
-     * Test that NON_RETRYABLE_ERRORS constant covers the legacy plugin codes
-     * plus the broader set introduced for the WordPress 7.0 core AI Client.
+     * Test that NON_RETRYABLE_ERRORS contains only permanent-failure codes.
      *
-     * `http_request_failed` is intentionally NOT in this list: WordPress uses
-     * it for transient transport failures (timeouts, network glitches) which
-     * should be retried.
+     * Transient codes (rate_limit_exceeded, http_request_failed) are
+     * intentionally excluded so the retry loop can wait and try again.
      */
     public function test_non_retryable_errors_constant(): void
     {
         $codes = Review_Service::NON_RETRYABLE_ERRORS;
 
-        $this->assertContains('rate_limit_exceeded', $codes);
         $this->assertContains('invalid_api_key', $codes);
         $this->assertContains('billing_error', $codes);
         $this->assertContains('rest_forbidden', $codes);
+        $this->assertNotContains('rate_limit_exceeded', $codes);
         $this->assertNotContains('http_request_failed', $codes);
     }
 
@@ -154,6 +152,31 @@ class ReviewServiceRetryTest extends TestCase
         $reflection->setAccessible(true);
 
         $this->assertFalse($reflection->invoke($this->service, $error));
+    }
+
+    /**
+     * call_ai() returns ai_client_missing when the WP 7.0 AI Client function
+     * is not available, instead of throwing or fataling.
+     */
+    public function test_call_ai_returns_error_when_function_missing(): void
+    {
+        $this->assertFalse(
+            function_exists('wp_ai_client_prompt'),
+            'Test environment unexpectedly defines wp_ai_client_prompt(); the early-return path cannot be exercised.'
+        );
+
+        $reflection = new ReflectionMethod(Review_Service::class, 'call_ai');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke(
+            $this->service,
+            'prompt',
+            'system',
+            'model'
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('ai_client_missing', $result->get_error_code());
     }
 
     /**
@@ -221,13 +244,18 @@ class ReviewServiceRetryTest extends TestCase
     }
 
     /**
-     * Test that rate_limit_exceeded error fails immediately.
+     * Test that a rate_limit_exceeded error is retried with backoff.
+     *
+     * Rate limits are transient: the right behaviour is to wait and try
+     * again, not to abort the review.
      */
-    public function test_rate_limit_exceeded_fails_immediately(): void
+    public function test_rate_limit_exceeded_is_retried(): void
     {
-        $error = new WP_Error('rate_limit_exceeded', 'Rate limit exceeded');
+        $mock_response = '{"feedback": []}';
+        $error         = new WP_Error('rate_limit_exceeded', 'Rate limit exceeded');
 
-        $this->service->call_ai_responses = array( $error );
+        // Fail twice, then succeed.
+        $this->service->call_ai_responses = array( $error, $error, $mock_response );
 
         $result = $this->service->test_call_ai_with_retry(
             'test prompt',
@@ -236,9 +264,8 @@ class ReviewServiceRetryTest extends TestCase
             3
         );
 
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('rate_limit_exceeded', $result->get_error_code());
-        $this->assertSame(1, $this->service->call_ai_count);
+        $this->assertSame($mock_response, $result);
+        $this->assertSame(3, $this->service->call_ai_count);
     }
 
     /**

--- a/tests/php/SettingsControllerStatusTest.php
+++ b/tests/php/SettingsControllerStatusTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Tests for Settings_Controller::get_status() connector detection.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Settings_Controller;
+
+/**
+ * Subclass that lets each test simulate a different Connectors API state
+ * without redefining global functions.
+ */
+class TestableSettingsController extends Settings_Controller {
+
+	/**
+	 * Override flag: when true, has_ai_provider_connector() returns true.
+	 *
+	 * @var bool
+	 */
+	public bool $force_has_ai_provider = false;
+
+	/**
+	 * Override flag: when true, has_ai_provider_connector() returns the value
+	 * of $force_has_ai_provider; otherwise it falls through to the parent
+	 * implementation which checks function_exists('wp_get_connectors').
+	 *
+	 * @var bool
+	 */
+	public bool $override_active = true;
+
+	/**
+	 * Allow tests to control the connector check directly.
+	 *
+	 * @return bool Connector availability per test fixture.
+	 */
+	protected function has_ai_provider_connector(): bool {
+		if ( $this->override_active ) {
+			return $this->force_has_ai_provider;
+		}
+		return parent::has_ai_provider_connector();
+	}
+}
+
+/**
+ * Test cases for the connector_configured branch of get_status().
+ *
+ * The three states tested correspond to:
+ *   1. wp_get_connectors() unavailable / no AI providers (returns false).
+ *   2. AI provider connector registered (returns true).
+ *   3. Settings URL is always emitted regardless of connector state.
+ */
+class SettingsControllerStatusTest extends TestCase {
+
+	/**
+	 * connector_configured is false when has_ai_provider_connector() returns false.
+	 */
+	public function test_connector_configured_false_when_no_provider(): void {
+		$controller                       = new TestableSettingsController();
+		$controller->override_active      = true;
+		$controller->force_has_ai_provider = false;
+
+		$data = $controller->get_status()->get_data();
+
+		$this->assertArrayHasKey( 'connector_configured', $data );
+		$this->assertFalse( $data['connector_configured'] );
+	}
+
+	/**
+	 * connector_configured is true when at least one AI provider is registered.
+	 */
+	public function test_connector_configured_true_when_provider_present(): void {
+		$controller                       = new TestableSettingsController();
+		$controller->override_active      = true;
+		$controller->force_has_ai_provider = true;
+
+		$data = $controller->get_status()->get_data();
+
+		$this->assertTrue( $data['connector_configured'] );
+	}
+
+	/**
+	 * Status payload always includes the Connectors admin URL.
+	 */
+	public function test_settings_url_points_to_connectors_screen(): void {
+		$controller                  = new TestableSettingsController();
+		$controller->override_active = true;
+
+		$data = $controller->get_status()->get_data();
+
+		$this->assertArrayHasKey( 'settings_url', $data );
+		$this->assertStringContainsString( 'page=connectors', $data['settings_url'] );
+	}
+
+	/**
+	 * Real has_ai_provider_connector() returns false when wp_get_connectors() is missing.
+	 *
+	 * The bootstrap does not define wp_get_connectors(), so this exercises the
+	 * function-missing branch directly.
+	 */
+	public function test_has_ai_provider_connector_returns_false_without_connectors_api(): void {
+		$controller                  = new TestableSettingsController();
+		$controller->override_active = false;
+
+		$data = $controller->get_status()->get_data();
+
+		$this->assertFalse( $data['connector_configured'] );
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -251,6 +251,76 @@ if (! function_exists('is_wp_error') ) {
 
 // Load classes that depend on WP REST and WP_Error mocks.
 require_once $includes_dir . 'class-health-controller.php';
+require_once $includes_dir . 'class-settings-controller.php';
+
+// Mock WP REST request and additional response helpers needed by Settings_Controller.
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params = array();
+		public function has_param( $key ) {
+			return array_key_exists( $key, $this->params );
+		}
+		public function get_param( $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+		public function set_param( $key, $value ) {
+			$this->params[ $key ] = $value;
+		}
+	}
+}
+
+if ( ! function_exists( 'admin_url' ) ) {
+	function admin_url( $path = '', $scheme = 'admin' ) {
+		return 'http://example.test/wp-admin/' . ltrim( $path, '/' );
+	}
+}
+
+if ( ! function_exists( 'rest_ensure_response' ) ) {
+	function rest_ensure_response( $response ) {
+		if ( $response instanceof \WP_REST_Response ) {
+			return $response;
+		}
+		return new \WP_REST_Response( $response );
+	}
+}
+
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( $namespace, $route, $args ) {
+		// No-op for unit tests.
+	}
+}
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return $GLOBALS['test_options'][ $name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $name, $value, $autoload = null ) {
+		$GLOBALS['test_options'][ $name ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $key, $value, $expiration = 0 ) {
+		$GLOBALS['test_transients'][ $key ] = $value;
+		return true;
+	}
+}
+
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $key ) {
+		return $GLOBALS['test_transients'][ $key ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( $path = '' ) {
+		return 'http://example.test/wp-json/' . ltrim( $path, '/' );
+	}
+}
 
 // Mock WordPress sanitization functions.
 if (! function_exists('wp_kses_post') ) {


### PR DESCRIPTION
Closes #142

## Summary

Drops the `wordpress/php-ai-client` Composer dependency and the AI
Experiments plugin prerequisite in favor of the WordPress 7.0 core AI
Client (`wp_ai_client_prompt()`) and Connectors API.

- Backend: rewrite `Review_Service::call_ai()` to use the core builder
  (snake_case fluent methods, native `WP_Error` returns), drop the
  exception-to-error-code translation, and detect availability with
  `function_exists( 'wp_ai_client_prompt' )`.
- Settings/Health: surface the Connectors admin screen
  (`options-general.php?page=connectors`) and report whether at least
  one `ai_provider` connector is registered.
- Frontend: point the welcome modal and `ai_request_failed` billing
  action button at the Connectors screen instead of the AI Experiments
  plugin / unregistered settings page.
- Docs: refresh `readme.txt`, `README.md`, and `CLAUDE.md` for WP 7.0
  + PHP 8.1, link the new dev notes, and add a 0.2.0 changelog entry.
- Bootstrap: raise the `Requires at least` / `Requires PHP` headers,
  bump the version constant to `0.2.0`, drop `Requires Plugins: ai`,
  and replace the AI Experiments admin notice with one keyed on the
  core AI Client function.

## Acceptance Criteria

- [x] Plugin requires WordPress 7.0+ to activate and run.
- [x] All custom AI connection / provider-management glue is removed
      in favor of core APIs (no API key UI in this plugin).
- [x] Plugin solely relies on WordPress 7.0+ AI and Connectors
      features for any AI integrations.
- [x] User documentation and onboarding are updated.

## Test plan

- [x] `vendor/bin/phpunit` — retry-logic tests pass; one pre-existing
      `ResponseParserGroupingTest` failure (undefined
      `wp_json_encode` in bootstrap) is unrelated to this change.
- [x] `vendor/bin/phpcs --standard=WordPress includes/`
- [x] `vendor/bin/phpstan analyze --memory-limit 1G`
- [x] `npm run lint:js`
- [x] `npm run build`
- [ ] Manual: install on a WordPress 7.0 site, configure an AI
      provider via Settings → Connectors, run a review.

## References

- [Introducing the AI Client in WordPress 7.0](https://make.wordpress.org/core/2026/03/24/introducing-the-ai-client-in-wordpress-7-0/)
- [Introducing the Connectors API in WordPress 7.0](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/)