### PR TITLE
Add priority scoring for feedback items (#57)

### DIFF
--- a/includes/class-response-parser.php
+++ b/includes/class-response-parser.php
@@ -46,6 +46,48 @@ class Response_Parser {
 	);
 
 	/**
+	 * Severity weights used by calculate_priority().
+	 */
+	public const PRIORITY_SEVERITY_WEIGHTS = array(
+		'critical'   => 100,
+		'important'  => 50,
+		'suggestion' => 10,
+	);
+
+	/**
+	 * Category weights used by calculate_priority().
+	 */
+	public const PRIORITY_CATEGORY_WEIGHTS = array(
+		'content' => 30,
+		'flow'    => 20,
+		'tone'    => 15,
+		'design'  => 10,
+	);
+
+	/**
+	 * Block-type weights used by calculate_priority().
+	 *
+	 * Blocks not listed here fall back to PRIORITY_BLOCK_DEFAULT.
+	 */
+	public const PRIORITY_BLOCK_WEIGHTS = array(
+		'core/heading'   => 15,
+		'core/list'      => 10,
+		'core/quote'     => 10,
+		'core/paragraph' => 5,
+	);
+
+	/**
+	 * Default block-type weight when a block is not in PRIORITY_BLOCK_WEIGHTS.
+	 */
+	public const PRIORITY_BLOCK_DEFAULT = 5;
+
+	/**
+	 * Score thresholds clients use to bucket priorities into high / medium / low.
+	 */
+	public const PRIORITY_HIGH_THRESHOLD   = 100;
+	public const PRIORITY_MEDIUM_THRESHOLD = 50;
+
+	/**
 	 * Parse an AI response and extract validated feedback items with an optional summary.
 	 *
 	 * Given the raw AI response text, attempts to extract and decode JSON, validates and
@@ -158,7 +200,8 @@ class Response_Parser {
 		foreach ( $feedback_items as $item ) {
 			$validated = $this->validate_feedback_item( $item, $valid_block_ids, $block_info );
 			if ( $validated ) {
-				$parsed[] = $validated;
+				$validated['priority'] = $this->calculate_priority( $validated );
+				$parsed[]              = $validated;
 			}
 		}
 
@@ -169,10 +212,72 @@ class Response_Parser {
 
 		Logger::debug( sprintf( 'Grouped into %d feedback items', count( $grouped ) ) );
 
+		// Sort by priority so the most impactful feedback surfaces first.
+		$grouped = $this->sort_by_priority( $grouped );
+
 		return array(
 			'summary'  => $this->sanitize_summary( $summary ),
 			'feedback' => $grouped,
 		);
+	}
+
+	/**
+	 * Calculate a priority score for a single feedback item.
+	 *
+	 * Combines severity (largest factor), category, block type, and a small
+	 * position bonus for early blocks. The score is bucketed by clients into
+	 * high / medium / low using PRIORITY_*_THRESHOLD constants.
+	 *
+	 * @param  array $item Validated feedback item. Expected keys: `severity`,
+	 *                     `category`, optional `block_name`, optional `block_index`.
+	 * @return int Priority score (higher means more important).
+	 */
+	public function calculate_priority( array $item ): int {
+		$score = 0;
+
+		$severity = $item['severity'] ?? '';
+		$score   += self::PRIORITY_SEVERITY_WEIGHTS[ $severity ] ?? 0;
+
+		$category = $item['category'] ?? '';
+		$score   += self::PRIORITY_CATEGORY_WEIGHTS[ $category ] ?? 0;
+
+		$block_name = $item['block_name'] ?? '';
+		$score     += self::PRIORITY_BLOCK_WEIGHTS[ $block_name ] ?? self::PRIORITY_BLOCK_DEFAULT;
+
+		// First five blocks get a decreasing bonus (25, 20, 15, 10, 5, then 0).
+		if ( isset( $item['block_index'] ) && is_int( $item['block_index'] ) ) {
+			$score += max( 0, 25 - ( $item['block_index'] * 5 ) );
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Sort feedback items by priority score, highest first.
+	 *
+	 * Items without a `priority` key are treated as zero. Items with the same
+	 * priority preserve their relative order (PHP `usort` is not stable, so
+	 * ties fall back to `block_index` then to original ordering).
+	 *
+	 * @param  array $feedback Feedback items, each expected to have an integer `priority`.
+	 * @return array Feedback items sorted by descending priority.
+	 */
+	public function sort_by_priority( array $feedback ): array {
+		usort(
+			$feedback,
+			static function ( array $a, array $b ): int {
+				$pa = $a['priority'] ?? 0;
+				$pb = $b['priority'] ?? 0;
+				if ( $pa !== $pb ) {
+					return $pb - $pa;
+				}
+				$ia = $a['block_index'] ?? PHP_INT_MAX;
+				$ib = $b['block_index'] ?? PHP_INT_MAX;
+				return $ia - $ib;
+			}
+		);
+
+		return $feedback;
 	}
 
 	/**
@@ -639,6 +744,10 @@ class Response_Parser {
 				if ( $this->severity_rank( $item['severity'] ) >
 					$this->severity_rank( $groups[ $key ]['severity'] ) ) {
 					$groups[ $key ]['severity'] = $item['severity'];
+				}
+				// Keep highest priority across grouped items.
+				if ( isset( $item['priority'] ) && $item['priority'] > ( $groups[ $key ]['priority'] ?? 0 ) ) {
+					$groups[ $key ]['priority'] = $item['priority'];
 				}
 				// Preserve block_name and block_index arrays.
 				if ( ! empty( $item['block_name'] ) ) {

--- a/src/components/FeedbackItem.js
+++ b/src/components/FeedbackItem.js
@@ -49,6 +49,63 @@ function getSeverityBadge(severity) {
 }
 
 /**
+ * Score thresholds — kept in sync with PRIORITY_*_THRESHOLD in
+ * includes/class-response-parser.php so PHP and JS bucket scores identically.
+ */
+const PRIORITY_HIGH_THRESHOLD = 100;
+const PRIORITY_MEDIUM_THRESHOLD = 50;
+
+/**
+ * Bucket a numeric priority score into 'high' | 'medium' | 'low'.
+ *
+ * @param {number} score Priority score.
+ * @return {string} Priority level.
+ */
+export function getPriorityLevel(score) {
+	if (typeof score !== 'number' || Number.isNaN(score)) {
+		return 'low';
+	}
+	if (score >= PRIORITY_HIGH_THRESHOLD) {
+		return 'high';
+	}
+	if (score >= PRIORITY_MEDIUM_THRESHOLD) {
+		return 'medium';
+	}
+	return 'low';
+}
+
+/**
+ * Priority indicator badge.
+ *
+ * @param {Object} props          Component props.
+ * @param {number} props.priority Priority score.
+ * @return {Element|null} Badge element or null when no score is available.
+ */
+function PriorityBadge({ priority }) {
+	if (typeof priority !== 'number') {
+		return null;
+	}
+
+	const level = getPriorityLevel(priority);
+	const labels = {
+		high: __('High priority', 'ai-feedback'),
+		medium: __('Medium priority', 'ai-feedback'),
+		low: __('Low priority', 'ai-feedback'),
+	};
+
+	return (
+		<span
+			className={`priority-badge priority-${level}`}
+			role="img"
+			aria-label={labels[level]}
+			title={labels[level]}
+		>
+			{level === 'high' ? '!' : ''}
+		</span>
+	);
+}
+
+/**
  * Get severity label.
  *
  * @param {string} severity Severity level.
@@ -87,6 +144,7 @@ function SingleFeedbackItem({ item, onNavigate }) {
 					>
 						{getSeverityBadge(item.severity)}
 					</span>
+					<PriorityBadge priority={item.priority} />
 					<strong className="feedback-title">{item.title}</strong>
 				</div>
 
@@ -145,6 +203,7 @@ function GroupedFeedbackItem({ item, onNavigate }) {
 						>
 							{getSeverityBadge(item.severity)}
 						</span>
+						<PriorityBadge priority={item.priority} />
 						<span className="group-title">{item.title}</span>
 						<Icon
 							icon={expanded ? chevronUp : chevronDown}

--- a/src/components/FeedbackList.js
+++ b/src/components/FeedbackList.js
@@ -1,10 +1,74 @@
 /**
  * Feedback List Component
  *
- * Displays a list of feedback items (grouped and individual).
+ * Displays a list of feedback items (grouped and individual) with a
+ * user-controlled sort order.
  */
 import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
 import FeedbackItem from './FeedbackItem';
+
+const SORT_PRIORITY = 'priority';
+const SORT_DOCUMENT = 'document';
+const SORT_CATEGORY = 'category';
+
+/**
+ * Best-effort document position for an item, handling both single and grouped
+ * shapes (groups expose `block_indexes` instead of `block_index`).
+ *
+ * @param {Object} item Feedback item.
+ * @return {number} Position used for ordering.
+ */
+function getDocumentPosition(item) {
+	if (typeof item.block_index === 'number') {
+		return item.block_index;
+	}
+	if (Array.isArray(item.block_indexes) && item.block_indexes.length > 0) {
+		return Math.min(...item.block_indexes);
+	}
+	return Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Sort feedback items by the requested order. Returns a new array.
+ *
+ * @param {Array}  items  Feedback items.
+ * @param {string} sortBy Sort key.
+ * @return {Array} Sorted feedback items.
+ */
+function sortFeedback(items, sortBy) {
+	const sorted = [...items];
+	switch (sortBy) {
+		case SORT_DOCUMENT:
+			sorted.sort(
+				(a, b) => getDocumentPosition(a) - getDocumentPosition(b)
+			);
+			break;
+		case SORT_CATEGORY:
+			sorted.sort((a, b) => {
+				const ca = a.category || '';
+				const cb = b.category || '';
+				if (ca !== cb) {
+					return ca.localeCompare(cb);
+				}
+				return (b.priority || 0) - (a.priority || 0);
+			});
+			break;
+		case SORT_PRIORITY:
+		default:
+			sorted.sort((a, b) => {
+				const pa = a.priority || 0;
+				const pb = b.priority || 0;
+				if (pa !== pb) {
+					return pb - pa;
+				}
+				return getDocumentPosition(a) - getDocumentPosition(b);
+			});
+			break;
+	}
+	return sorted;
+}
 
 /**
  * Feedback list component.
@@ -14,32 +78,63 @@ import FeedbackItem from './FeedbackItem';
  * @return {Element|null} Feedback list component.
  */
 export default function FeedbackList({ feedbackItems }) {
+	const [sortBy, setSortBy] = useState(SORT_PRIORITY);
+
+	const sortedItems = useMemo(
+		() => sortFeedback(feedbackItems || [], sortBy),
+		[feedbackItems, sortBy]
+	);
+
 	if (!feedbackItems || feedbackItems.length === 0) {
 		return null;
 	}
 
 	return (
-		<div
-			id="ai-feedback-items"
-			className="ai-feedback-list"
-			role="list"
-			aria-label={__('Feedback items', 'ai-feedback')}
-		>
-			{feedbackItems.map((item, index) => {
-				// For grouped items, use the first block_id from block_ids array
-				// For single items, use block_id directly
-				// Fallback to index if neither is available
-				const key =
-					item.id ||
-					(item.is_group ? item.block_ids?.[0] : item.block_id) ||
-					`item-${index}`;
+		<>
+			<div className="ai-feedback-list-controls">
+				<SelectControl
+					label={__('Sort by', 'ai-feedback')}
+					value={sortBy}
+					options={[
+						{
+							label: __('Priority (recommended)', 'ai-feedback'),
+							value: SORT_PRIORITY,
+						},
+						{
+							label: __('Document order', 'ai-feedback'),
+							value: SORT_DOCUMENT,
+						},
+						{
+							label: __('Category', 'ai-feedback'),
+							value: SORT_CATEGORY,
+						},
+					]}
+					onChange={setSortBy}
+					__nextHasNoMarginBottom
+				/>
+			</div>
+			<div
+				id="ai-feedback-items"
+				className="ai-feedback-list"
+				role="list"
+				aria-label={__('Feedback items', 'ai-feedback')}
+			>
+				{sortedItems.map((item, index) => {
+					// For grouped items, use the first block_id from block_ids array.
+					// For single items, use block_id directly.
+					// Fallback to index if neither is available.
+					const key =
+						item.id ||
+						(item.is_group ? item.block_ids?.[0] : item.block_id) ||
+						`item-${index}`;
 
-				return (
-					<div key={key} role="listitem">
-						<FeedbackItem item={item} />
-					</div>
-				);
-			})}
-		</div>
+					return (
+						<div key={key} role="listitem">
+							<FeedbackItem item={item} />
+						</div>
+					);
+				})}
+			</div>
+		</>
 	);
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -464,12 +464,47 @@ $ai-feedback-text-muted: #595959;
 	}
 }
 
+/* Feedback List Sort Controls */
+.ai-feedback-list-controls {
+	margin-top: 16px;
+	margin-bottom: 8px;
+}
+
 /* Feedback List Styles */
 .ai-feedback-list {
-	margin-top: 16px;
+	margin-top: 8px;
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
+}
+
+/* Priority Indicator Badge */
+.priority-badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 6px;
+	border-radius: 9px;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1;
+	color: #fff;
+
+	&.priority-high {
+		background: #d63638;
+	}
+
+	&.priority-medium {
+		background: #dba617;
+	}
+
+	&.priority-low {
+
+		/* Low priority is implied; render nothing rather than a dim chip. */
+		display: none;
+	}
 }
 
 /* Feedback Item Styles */

--- a/tests/php/ResponseParserPriorityTest.php
+++ b/tests/php/ResponseParserPriorityTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Tests for Response_Parser priority scoring.
+ *
+ * @package AI_Feedback\Tests
+ */
+
+namespace AI_Feedback\Tests;
+
+use PHPUnit\Framework\TestCase;
+use AI_Feedback\Response_Parser;
+
+/**
+ * Test cases for Response_Parser priority scoring and sorting.
+ */
+class ResponseParserPriorityTest extends TestCase {
+
+	/**
+	 * Parser instance.
+	 *
+	 * @var Response_Parser
+	 */
+	private Response_Parser $parser;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->parser = new Response_Parser();
+	}
+
+	/**
+	 * Critical severity should dominate the score.
+	 */
+	public function test_critical_severity_outweighs_other_factors(): void {
+		$critical_paragraph = $this->parser->calculate_priority(
+			array(
+				'severity'    => 'critical',
+				'category'    => 'design',
+				'block_name'  => 'core/paragraph',
+				'block_index' => 10,
+			)
+		);
+
+		$suggestion_heading = $this->parser->calculate_priority(
+			array(
+				'severity'    => 'suggestion',
+				'category'    => 'content',
+				'block_name'  => 'core/heading',
+				'block_index' => 0,
+			)
+		);
+
+		$this->assertGreaterThan(
+			$suggestion_heading,
+			$critical_paragraph,
+			'Critical items should outrank suggestion items even when other factors favour the suggestion.'
+		);
+	}
+
+	/**
+	 * Position bonus should taper after the first five blocks.
+	 */
+	public function test_position_bonus_decays_to_zero(): void {
+		$base_item = array(
+			'severity'   => 'important',
+			'category'   => 'content',
+			'block_name' => 'core/paragraph',
+		);
+
+		$first  = $this->parser->calculate_priority( $base_item + array( 'block_index' => 0 ) );
+		$fifth  = $this->parser->calculate_priority( $base_item + array( 'block_index' => 5 ) );
+		$tenth  = $this->parser->calculate_priority( $base_item + array( 'block_index' => 10 ) );
+		$twenty = $this->parser->calculate_priority( $base_item + array( 'block_index' => 20 ) );
+
+		$this->assertSame( $first - 25, $fifth, 'First block should get a 25-point bonus.' );
+		$this->assertSame( $fifth, $tenth, 'Position bonus should clamp at zero past block index 5.' );
+		$this->assertSame( $tenth, $twenty, 'Position bonus should not go negative for far-back blocks.' );
+	}
+
+	/**
+	 * Unknown enum values should default cleanly to zero / default weight.
+	 */
+	public function test_unknown_values_use_safe_defaults(): void {
+		$score = $this->parser->calculate_priority(
+			array(
+				'severity'   => 'unknown_severity',
+				'category'   => 'unknown_category',
+				'block_name' => 'core/spacer',
+			)
+		);
+
+		// Default block weight of 5, no severity/category contribution, no position bonus.
+		$this->assertSame( Response_Parser::PRIORITY_BLOCK_DEFAULT, $score );
+	}
+
+	/**
+	 * sort_by_priority returns items in descending priority order.
+	 */
+	public function test_sort_by_priority_orders_descending(): void {
+		$items = array(
+			array( 'priority' => 30, 'block_id' => 'low' ),
+			array( 'priority' => 130, 'block_id' => 'high' ),
+			array( 'priority' => 70, 'block_id' => 'mid' ),
+		);
+
+		$sorted = $this->parser->sort_by_priority( $items );
+
+		$this->assertSame( 'high', $sorted[0]['block_id'] );
+		$this->assertSame( 'mid', $sorted[1]['block_id'] );
+		$this->assertSame( 'low', $sorted[2]['block_id'] );
+	}
+
+	/**
+	 * Ties on priority should fall back to block_index ascending so the
+	 * earliest block wins, keeping document order within a priority bucket.
+	 */
+	public function test_sort_by_priority_breaks_ties_by_block_index(): void {
+		$items = array(
+			array( 'priority' => 50, 'block_index' => 3, 'block_id' => 'b3' ),
+			array( 'priority' => 50, 'block_index' => 1, 'block_id' => 'b1' ),
+			array( 'priority' => 50, 'block_index' => 2, 'block_id' => 'b2' ),
+		);
+
+		$sorted = $this->parser->sort_by_priority( $items );
+
+		$this->assertSame( array( 'b1', 'b2', 'b3' ), array_column( $sorted, 'block_id' ) );
+	}
+
+	/**
+	 * Items missing priority entirely should be treated as zero and sink to the bottom.
+	 */
+	public function test_sort_by_priority_treats_missing_as_zero(): void {
+		$items = array(
+			array( 'block_id' => 'no_priority' ),
+			array( 'priority' => 1, 'block_id' => 'low_priority' ),
+		);
+
+		$sorted = $this->parser->sort_by_priority( $items );
+
+		$this->assertSame( 'low_priority', $sorted[0]['block_id'] );
+		$this->assertSame( 'no_priority', $sorted[1]['block_id'] );
+	}
+
+	/**
+	 * Grouping should keep the highest priority across grouped items.
+	 */
+	public function test_grouping_preserves_highest_priority(): void {
+		$feedback = array(
+			array(
+				'block_id'   => 'a',
+				'category'   => 'content',
+				'severity'   => 'suggestion',
+				'title'      => 'Fix passive voice',
+				'feedback'   => 'Use active voice.',
+				'block_name' => 'core/paragraph',
+				'priority'   => 45,
+			),
+			array(
+				'block_id'   => 'b',
+				'category'   => 'content',
+				'severity'   => 'critical',
+				'title'      => 'Fix passive voice',
+				'feedback'   => 'Use active voice.',
+				'block_name' => 'core/heading',
+				'priority'   => 145,
+			),
+		);
+
+		$grouped = $this->parser->group_similar_feedback( $feedback );
+
+		$this->assertCount( 1, $grouped );
+		$this->assertTrue( $grouped[0]['is_group'] );
+		$this->assertSame( 145, $grouped[0]['priority'], 'Group should retain the highest member priority.' );
+	}
+
+	/**
+	 * End-to-end: parse_feedback should surface critical items above suggestions
+	 * regardless of the order in which the AI returned them.
+	 */
+	public function test_parse_feedback_sorts_critical_first(): void {
+		$blocks = array(
+			array( 'clientId' => 'block-1', 'name' => 'core/paragraph' ),
+			array( 'clientId' => 'block-2', 'name' => 'core/heading' ),
+		);
+
+		$response = json_encode(
+			array(
+				'summary'  => 'Looks fine.',
+				'feedback' => array(
+					array(
+						'block_id' => 'block-1',
+						'category' => 'design',
+						'severity' => 'suggestion',
+						'title'    => 'Tweak spacing',
+						'feedback' => 'Consider adjusting spacing.',
+					),
+					array(
+						'block_id' => 'block-2',
+						'category' => 'content',
+						'severity' => 'critical',
+						'title'    => 'Fix factual error',
+						'feedback' => 'This statement is incorrect.',
+					),
+				),
+			)
+		);
+
+		$parsed = $this->parser->parse_feedback( $response, $blocks );
+
+		$this->assertIsArray( $parsed );
+		$this->assertCount( 2, $parsed['feedback'] );
+		$this->assertSame( 'critical', $parsed['feedback'][0]['severity'] );
+		$this->assertSame( 'block-2', $parsed['feedback'][0]['block_id'] );
+		$this->assertArrayHasKey( 'priority', $parsed['feedback'][0] );
+		$this->assertGreaterThan(
+			$parsed['feedback'][1]['priority'],
+			$parsed['feedback'][0]['priority']
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#57](https://github.com/adamsilverstein/ai-feedback/issues/57). Each feedback item now gets a priority score based on severity, category, block type, and document position. The list defaults to sorting by priority so the most impactful items surface first, and users can opt into document order or category sort.

- **PHP**: `Response_Parser::calculate_priority()` and `sort_by_priority()` are wired into `parse_feedback()`. Grouped items keep the highest priority among their members. Thresholds (`PRIORITY_HIGH_THRESHOLD`, `PRIORITY_MEDIUM_THRESHOLD`) are exposed as class constants so the JS UI can mirror them.
- **JS**: `PriorityBadge` renders `!` for high priority and a chip for medium; low priority is implied. `FeedbackList` gets a `SelectControl` to switch between Priority, Document order, and Category sort.

## Scoring weights

| Factor | Weight |
|--------|--------|
| Critical severity | +100 |
| Important severity | +50 |
| Suggestion severity | +10 |
| `content` category | +30 |
| `flow` category | +20 |
| `tone` category | +15 |
| `design` category | +10 |
| `core/heading` block | +15 |
| `core/list` / `core/quote` block | +10 |
| `core/paragraph` (and default) block | +5 |
| Position bonus (block index 0) | +25, decaying by 5 per block to 0 at index 5 |

## Test plan

- [x] `vendor/bin/phpunit --filter ResponseParserPriorityTest` — 8 tests, 20 assertions pass
- [x] `vendor/bin/phpunit` — 113/114 pass (1 pre-existing failure in `test_grouping_integrated_in_parse_feedback` due to `wp_json_encode` not being shimmed in the test bootstrap; unrelated to this change)
- [x] `composer phpcs` — clean
- [x] `composer phpstan` — clean
- [x] `npm run lint:js` — clean
- [x] `npm run build` — clean
- [ ] Manual: trigger a review in the editor, confirm sort selector works and badges render